### PR TITLE
CardTypeId beside CardType in StatusInformation & Completionbytes in CommandResponse

### DIFF
--- a/src/Portalum.Zvt/CommandResponse.cs
+++ b/src/Portalum.Zvt/CommandResponse.cs
@@ -15,6 +15,8 @@
         /// </summary>
         public string ErrorMessage { get; set; }
 
+        public byte[] CompletionBytes { get; set; }
+
         /// <inheritdoc />
         public override string ToString()
         {

--- a/src/Portalum.Zvt/IReceiveHandler.cs
+++ b/src/Portalum.Zvt/IReceiveHandler.cs
@@ -11,7 +11,7 @@ namespace Portalum.Zvt
         /// <summary>
         /// Command Completion received
         /// </summary>
-        event Action CompletionReceived;
+        event Action<Byte[]> CompletionReceived;
 
         /// <summary>
         /// Command Abort received

--- a/src/Portalum.Zvt/Models/StatusInformation.cs
+++ b/src/Portalum.Zvt/Models/StatusInformation.cs
@@ -44,5 +44,6 @@ namespace Portalum.Zvt.Models
         public int CardSequenceNumber { get; set; }
         public int TurnoverRecordNumber { get; set; }
         public string CardType { get; set; }
+        public byte CardTypeId { get; set; }
     }
 }

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -609,6 +609,7 @@ namespace Portalum.Zvt.Parsers
                 }
 
                 typedResponse.CardType = cardType;
+                typedResponse.CardTypeId = data[0];
 
                 return true;
             }

--- a/src/Portalum.Zvt/ReceiveHandler.cs
+++ b/src/Portalum.Zvt/ReceiveHandler.cs
@@ -50,7 +50,7 @@ namespace Portalum.Zvt
         public event Action<string> IntermediateStatusInformationReceived;
 
         /// <inheritdoc />
-        public event Action CompletionReceived;
+        public event Action<byte[]> CompletionReceived;
 
         /// <inheritdoc />
         public event Action<string> AbortReceived;
@@ -260,7 +260,7 @@ namespace Portalum.Zvt
             if (apduInfo.CanHandle(this._completionCommandControlField))
             {
                 this._logger.LogDebug($"{nameof(ProcessApdu)} - 'Completion' received");
-                this.CompletionReceived?.Invoke();
+                this.CompletionReceived?.Invoke(apduData.ToArray());
                 return true;
             }
 

--- a/src/Portalum.Zvt/Responses/IResponseCardType.cs
+++ b/src/Portalum.Zvt/Responses/IResponseCardType.cs
@@ -3,5 +3,6 @@
     public interface IResponseCardType
     {
         string CardType { get; set; }
+        byte CardTypeId { get; set; }
     }
 }

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -209,10 +209,10 @@ namespace Portalum.Zvt
                 State = CommandResponseState.Unknown
             };
 
-            void completionReceived()
+            void completionReceived(byte[] CompletionBytes)
             {
                 commandResponse.State = CommandResponseState.Successful;
-
+                commandResponse.CompletionBytes = CompletionBytes;
                 dataReceivcedCancellationTokenSource.Cancel();
             }
 

--- a/src/Portalum.Zvt/ZvtCommunication.cs
+++ b/src/Portalum.Zvt/ZvtCommunication.cs
@@ -95,8 +95,6 @@ namespace Portalum.Zvt
             }
         }
 
-
-
         /// <summary>
         /// Send command
         /// </summary>


### PR DESCRIPTION
Hello,

we needed to extend the StatusInformation with the CardTypeId numeric value, like defined in ZVT documentation.  
I also had to use the ZvtClient's SendCommandAsync method and realized, that the completionbytes were missing. 
I used this method for "Status-Enquiry (05 01)" and needed the completion.

