### PR TITLE
proposal for implementing a callback to issue goods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ zvtClient.StatusInformationReceived += (statusInformation) => Console.WriteLine(
 await zvtClient.PaymentAsync(10.5M);
 ```
 
+### Start Payment with asyncronous completion
+
+```cs
+var deviceCommunication = new TcpNetworkDeviceCommunication("192.168.0.10");
+if (!await deviceCommunication.ConnectAsync())
+{
+    return;
+}
+
+using var zvtClient = new ZvtClient(deviceCommunication);
+
+CompletionInfo completionInfo = new CompletionInfo();
+zvtClient.GetAsyncCompletionInfo += () => completionInfo;
+zvtClient.StartAsyncCompletion += (_) =>
+{
+  // payment successful, start issuing goods to the customer
+  Task.Delay(3000).ContinueWith(task => completionInfo.State = CompletionInfoState.Successful);
+};
+
+
+await zvtClient.PaymentAsync(10.5M);
+
+```
+
 ### Start End-of-day
 ```cs
 var deviceCommunication = new TcpNetworkDeviceCommunication("192.168.0.10");

--- a/src/Portalum.Zvt.UnitTest/IntermediateStatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/IntermediateStatusInformationParserTest.cs
@@ -52,7 +52,12 @@ namespace Portalum.Zvt.UnitTest
             var parser = this.GetIntermediateStatusInformationParser();
             var statusMessage = parser.GetMessage(new byte[] { 0xFF, 0x10, 0x06, 0x1A, 0x24, 0x18, 0x07, 0x08, 0x45, 0x55, 0x52, 0x20, 0x31, 0x2E, 0x32, 0x33, 0x07, 0x0C, 0x42, 0x69, 0x74, 0x74, 0x65, 0x20, 0x77, 0x61, 0x72, 0x74, 0x65, 0x6E });
 
-            Assert.AreEqual("EUR 1.23\r\nBitte warten\r\n", statusMessage);
+            // Note, we use the same string builder which the parser uses, so line endings are the same in the asserted string (differs between nix and win)
+            var expectedMessage = new StringBuilder();
+            expectedMessage.AppendLine("EUR 1.23");
+            expectedMessage.AppendLine("Bitte warten");
+            
+            Assert.AreEqual(expectedMessage.ToString(), statusMessage);
         }
     }
 }

--- a/src/Portalum.Zvt.UnitTest/PrintLineTest.cs
+++ b/src/Portalum.Zvt.UnitTest/PrintLineTest.cs
@@ -195,7 +195,7 @@ namespace Portalum.Zvt.UnitTest
             {
                 var data = ByteHelper.HexToByteArray(hexLine);
                 var processDataState = receiveHandler.ProcessData(data);
-                Assert.AreEqual(processDataState, ProcessDataState.CannotProcess);
+                Assert.AreEqual(processDataState.State, ProcessDataState.CannotProcess);
             }
 
             receiveHandler.LineReceived -= ReceiveHandlerLineReceived;
@@ -218,7 +218,7 @@ namespace Portalum.Zvt.UnitTest
             {
                 var data = ByteHelper.HexToByteArray(hexLine);
                 var processDataState = receiveHandler.ProcessData(data);
-                Assert.AreEqual(processDataState, ProcessDataState.WaitForMoreData);
+                Assert.AreEqual(processDataState.State, ProcessDataState.WaitForMoreData);
             }
 
             receiveHandler.LineReceived -= ReceiveHandlerLineReceived;

--- a/src/Portalum.Zvt.UnitTest/ReceiveHandlerTest.cs
+++ b/src/Portalum.Zvt.UnitTest/ReceiveHandlerTest.cs
@@ -46,11 +46,11 @@ namespace Portalum.Zvt.UnitTest
 
                 if (i == hexLines.Length - 1)
                 {
-                    Assert.AreEqual(processDataState, ProcessDataState.Processed);
+                    Assert.AreEqual(processDataState.State, ProcessDataState.Processed);
                     continue;
                 }
 
-                Assert.AreEqual(processDataState, ProcessDataState.WaitForMoreData);
+                Assert.AreEqual(processDataState.State, ProcessDataState.WaitForMoreData);
             }
         }
 
@@ -72,11 +72,11 @@ namespace Portalum.Zvt.UnitTest
 
                 if (i == hexLines.Length - 1)
                 {
-                    Assert.AreEqual(processDataState, ProcessDataState.Processed);
+                    Assert.AreEqual(processDataState.State, ProcessDataState.Processed);
                     continue;
                 }
 
-                Assert.AreEqual(processDataState, ProcessDataState.WaitForMoreData);
+                Assert.AreEqual(processDataState.State, ProcessDataState.WaitForMoreData);
             }
         }
 
@@ -94,7 +94,7 @@ namespace Portalum.Zvt.UnitTest
             {
                 var data = ByteHelper.HexToByteArray(hexLine);
                 var processDataState = receiveHandler.ProcessData(data);
-                Assert.AreEqual(processDataState, ProcessDataState.Processed);
+                Assert.AreEqual(processDataState.State, ProcessDataState.Processed);
             }
         }
     }

--- a/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
@@ -31,6 +31,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("Abbruch durch Kunde", statusInformation.AdditionalText);
+            Assert.AreEqual(0x6C, statusInformation.ErrorCode);
             Assert.AreEqual("abort via timeout or abort-key", statusInformation.ErrorMessage);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
         }
@@ -47,6 +48,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("Betrag falsch", statusInformation.AdditionalText);
+            Assert.AreEqual(0xFF, statusInformation.ErrorCode);
             Assert.AreEqual("system error (= other/unknown error), See TLV tags 1F16 and 1F17", statusInformation.ErrorMessage);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
         }
@@ -126,6 +128,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual("MASTERCARD", statusInformation.CardName);
             Assert.AreEqual(6, statusInformation.TerminalIdentifier);
             Assert.AreEqual("no error", statusInformation.ErrorMessage);
+            Assert.AreEqual(0, statusInformation.ErrorCode);
             Assert.AreEqual("NFC", statusInformation.CardTechnology);
             Assert.AreEqual("No Cardholder authentication", statusInformation.CardholderAuthentication);
         }
@@ -145,6 +148,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual("MASTERCARD", statusInformation.CardName);
             Assert.AreEqual(6, statusInformation.TerminalIdentifier);
             Assert.AreEqual("no error", statusInformation.ErrorMessage);
+            Assert.AreEqual(0, statusInformation.ErrorCode);
             Assert.AreEqual("Chip", statusInformation.CardTechnology);
             Assert.AreEqual("Offline encrypted Pin", statusInformation.CardholderAuthentication);
         }
@@ -162,6 +166,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("abort via timeout or abort-key", statusInformation.ErrorMessage);
+            Assert.AreEqual(0x6C, statusInformation.ErrorCode);
             Assert.AreEqual(52500295, statusInformation.TerminalIdentifier);
             Assert.AreEqual(12, statusInformation.Amount);
             Assert.AreEqual(978, statusInformation.CurrencyCode);

--- a/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Portalum.Zvt.Helpers;
 using Portalum.Zvt.Parsers;
 using Portalum.Zvt.Repositories;
@@ -75,6 +77,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual(1, statusInformation.CardSequenceNumber);
             Assert.AreEqual(new TimeSpan(22, 39, 53), statusInformation.Time);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
+            Assert.AreEqual("4771", statusInformation.CardNumber[^4..]);
         }
 
         [TestMethod]

--- a/src/Portalum.Zvt.UnitTest/ZvtClientTest.cs
+++ b/src/Portalum.Zvt.UnitTest/ZvtClientTest.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Portalum.Zvt.Helpers;
 
 namespace Portalum.Zvt.UnitTest
 {
@@ -101,6 +103,247 @@ namespace Portalum.Zvt.UnitTest
 
             Assert.AreEqual(CommandResponseState.Abort, commandResponse.State);
             Assert.AreEqual("card not readable (LRC-/parity-error)", commandResponse.ErrorMessage);
+        }
+
+        [TestMethod]
+        public async Task PaymentAsync_SuccessfulPayment_Successful()
+        {
+            byte[] dataSent = Array.Empty<byte>();
+            var loggerZvtClient = LoggerHelper.GetLogger<ZvtClient>();
+            var mockDeviceCommunication = new Mock<IDeviceCommunication>();
+            mockDeviceCommunication
+                .Setup(c => c.SendAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task(byte[] data, CancellationToken token) =>
+                {
+                    dataSent = data;
+                    return Task.CompletedTask;
+                });
+
+            var clientConfig = new ZvtClientConfig
+            {
+                CommandCompletionTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var zvtClient = new ZvtClient(mockDeviceCommunication.Object, loggerZvtClient.Object, clientConfig);
+
+            var paymentTask = zvtClient.PaymentAsync(10);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x80, 0x00, 0x00 });
+            // ensure the timeout is not set, when nothing is passed to PaymentAsync
+            CollectionAssert.AreEqual(new byte[] { 0x06, 0x01, 0x07, 0x04, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 },
+                dataSent);
+
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null,
+                new byte[] { 0x04, 0x0F, 0x02, 0x27, 0x00 });
+            await Task.Delay(1000);
+
+            // check that the ECR answers immediately, as no issueGoodsCallback is set
+            CollectionAssert.AreEqual(new byte[] { 0x80, 0x00, 0x00 }, dataSent);
+
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x06, 0x0F, 0x00 });
+            await Task.Delay(1000);
+            var commandResponse = await paymentTask;
+
+            zvtClient.Dispose();
+            Assert.AreEqual(CommandResponseState.Successful, commandResponse.State);
+        }
+
+        [TestMethod]
+        public async Task PaymentAsync_CardRejected_Successful()
+        {
+            var loggerZvtClient = LoggerHelper.GetLogger<ZvtClient>();
+            var mockDeviceCommunication = new Mock<IDeviceCommunication>();
+
+            var clientConfig = new ZvtClientConfig
+            {
+                CommandCompletionTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var zvtClient = new ZvtClient(mockDeviceCommunication.Object, loggerZvtClient.Object, clientConfig);
+
+            var paymentTask = zvtClient.PaymentAsync(10);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x80, 0x00, 0x00 });
+
+            var dataHex = "04-0F-25-27-05-29-29-00-02-74-3C-F0-F0-F9-41-62-67-65-" +
+                          "6C-65-68-6E-74-8A-06-06-0D-24-0B-07-09-41-62-67-65-6C-65-68-6E-74";
+            var cardRejectedStatusInformation = ByteHelper.HexToByteArray(dataHex);
+
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, cardRejectedStatusInformation);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x06, 0x1E, 0x01, 0x05 });
+            await Task.Delay(1000);
+            var commandResponse = await paymentTask;
+
+            zvtClient.Dispose();
+            Assert.AreEqual(CommandResponseState.Abort, commandResponse.State);
+        }
+
+        [TestMethod]
+        public async Task PaymentAsync_IssueOfGoods_DelayedSuccess_Successful()
+        {
+            var taskStarted = false;
+            byte[] dataSent = Array.Empty<byte>();
+            var loggerZvtClient = LoggerHelper.GetLogger<ZvtClient>();
+            var mockDeviceCommunication = new Mock<IDeviceCommunication>();
+            mockDeviceCommunication
+                .Setup(c => c.SendAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task(byte[] data, CancellationToken token) =>
+                {
+                    dataSent = data;
+                    return Task.CompletedTask;
+                });
+
+            var clientConfig = new ZvtClientConfig
+            {
+                CommandCompletionTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var zvtClient = new ZvtClient(mockDeviceCommunication.Object, loggerZvtClient.Object, clientConfig);
+
+            var issueGoodsAfter3Seconds = async Task<bool>() =>
+            {
+                taskStarted = true;
+                await Task.Delay(3000);
+                return true;
+            };
+            
+            var paymentTask =
+                zvtClient.PaymentAsync(33, issueGoodsCallback: issueGoodsAfter3Seconds, issueGoodsTimeout: 5);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x80, 0x00, 0x00 });
+            CollectionAssert.AreEqual(new byte[] { 0x06, 0x01, 0x09, 0x04, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x01, 0x05 },
+                dataSent);
+            
+            dataSent = Array.Empty<byte>();
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null,
+                new byte[] { 0x04, 0x0F, 0x02, 0x27, 0x00 });
+            await Task.Delay(1000);
+
+            // after the status information has been received, the fulfill task is started 
+            Assert.IsTrue(taskStarted);
+
+            // ensure no answer is sent, until the task has finished
+            CollectionAssert.AreEqual(Array.Empty<byte>(), dataSent);
+
+            // after the task has finished, the answer is sent
+            await Task.Delay(3000); // 2 seconds remaining, 1 second for the ECR to answer
+            CollectionAssert.AreEqual(new byte[] { 0x80, 0x00, 0x00 }, dataSent);
+            
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x06, 0x0F, 0x00 });
+            var commandResponse = await paymentTask;
+
+            zvtClient.Dispose();
+            Assert.AreEqual(CommandResponseState.Successful, commandResponse.State);
+        }
+        
+        [TestMethod]
+        public async Task PaymentAsync_IssueOfGoods_DelayedFailure_Successful()
+        {
+            var taskStarted = false;
+            byte[] dataSent = Array.Empty<byte>();
+            var loggerZvtClient = LoggerHelper.GetLogger<ZvtClient>();
+            var mockDeviceCommunication = new Mock<IDeviceCommunication>();
+            mockDeviceCommunication
+                .Setup(c => c.SendAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task(byte[] data, CancellationToken token) =>
+                {
+                    dataSent = data;
+                    return Task.CompletedTask;
+                });
+
+            var clientConfig = new ZvtClientConfig
+            {
+                CommandCompletionTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var zvtClient = new ZvtClient(mockDeviceCommunication.Object, loggerZvtClient.Object, clientConfig);
+
+            var issueGoodsAfter3Seconds = async Task<bool>() =>
+            {
+                taskStarted = true;
+                await Task.Delay(3000);
+                return false;
+            };
+            
+            var paymentTask =
+                zvtClient.PaymentAsync(33, issueGoodsCallback: issueGoodsAfter3Seconds, issueGoodsTimeout: 5);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x80, 0x00, 0x00 });
+            CollectionAssert.AreEqual(new byte[] { 0x06, 0x01, 0x09, 0x04, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x01, 0x05 },
+                dataSent);
+            
+            dataSent = Array.Empty<byte>();
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null,
+                new byte[] { 0x04, 0x0F, 0x02, 0x27, 0x00 });
+            await Task.Delay(1000);
+
+            // after the status information has been received, the fulfill task is started 
+            Assert.IsTrue(taskStarted);
+
+            // ensure no answer is sent, until the task has finished
+            CollectionAssert.AreEqual(Array.Empty<byte>(), dataSent);
+
+            // after the task has finished, the answer is sent
+            await Task.Delay(3000); // 2 seconds remaining, 1 second for the ECR to answer
+            CollectionAssert.AreEqual(new byte[] { 0x84, 0x66, 0x00 }, dataSent);
+            
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x06, 0x1E, 0x01, 0x05 });
+            var commandResponse = await paymentTask;
+
+            zvtClient.Dispose();
+            Assert.AreEqual(CommandResponseState.Abort, commandResponse.State);
+        }
+        
+        [TestMethod]
+        public async Task PaymentAsync_IssueOfGoods_RejectedCard_Successful()
+        {
+            var taskStarted = false;
+            byte[] dataSent = Array.Empty<byte>();
+            var loggerZvtClient = LoggerHelper.GetLogger<ZvtClient>();
+            var mockDeviceCommunication = new Mock<IDeviceCommunication>();
+            mockDeviceCommunication
+                .Setup(c => c.SendAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task(byte[] data, CancellationToken token) =>
+                {
+                    dataSent = data;
+                    return Task.CompletedTask;
+                });
+
+            var clientConfig = new ZvtClientConfig
+            {
+                CommandCompletionTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var zvtClient = new ZvtClient(mockDeviceCommunication.Object, loggerZvtClient.Object, clientConfig);
+
+            var issueGoodsAfter3Seconds = async Task<bool>() =>
+            {
+                taskStarted = true;
+                await Task.Delay(3000);
+                return true;
+            };
+            
+            var paymentTask =
+                zvtClient.PaymentAsync(33, issueGoodsCallback: issueGoodsAfter3Seconds, issueGoodsTimeout: 5);
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x80, 0x00, 0x00 });
+            CollectionAssert.AreEqual(new byte[] { 0x06, 0x01, 0x09, 0x04, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x01, 0x05 },
+                dataSent);
+            
+            dataSent = Array.Empty<byte>();
+            var dataHex = "04-0F-25-27-05-29-29-00-02-74-3C-F0-F0-F9-41-62-67-65-" +
+                          "6C-65-68-6E-74-8A-06-06-0D-24-0B-07-09-41-62-67-65-6C-65-68-6E-74";
+            var cardRejectedStatusInformation = ByteHelper.HexToByteArray(dataHex);
+
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, cardRejectedStatusInformation);
+            await Task.Delay(1000);
+
+            // a not successful status information does not result in the issue goods task beeing started 
+            Assert.IsFalse(taskStarted);
+
+            // ensure we answer with an ack in this case
+            CollectionAssert.AreEqual(new byte[] { 0x80, 0x00, 0x00 }, dataSent);
+            
+            mockDeviceCommunication.Raise(mock => mock.DataReceived += null, new byte[] { 0x06, 0x1E, 0x01, 0x05 });
+            var commandResponse = await paymentTask;
+
+            zvtClient.Dispose();
+            Assert.AreEqual(CommandResponseState.Abort, commandResponse.State);
         }
     }
 }

--- a/src/Portalum.Zvt.UnitTest/ZvtCommunicationTest.cs
+++ b/src/Portalum.Zvt.UnitTest/ZvtCommunicationTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Portalum.Zvt.Models;
 using System.Linq;
@@ -14,10 +15,10 @@ namespace Portalum.Zvt.UnitTest
         {
             var additionalDataReceived = false;
 
-            bool dataReceived(byte[] data)
+            ProcessData dataReceived(byte[] data)
             {
                 additionalDataReceived = true;
-                return true;
+                return new ProcessData(ProcessDataState.Processed);
             }
 
             var loggerZvtCommunication = LoggerHelper.GetLogger<ZvtCommunication>();
@@ -43,11 +44,11 @@ namespace Portalum.Zvt.UnitTest
             var additionalDataReceived = false;
             byte[] additionalData = null;
 
-            bool dataReceived(byte[] data)
+            ProcessData dataReceived(byte[] data)
             {
                 additionalDataReceived = true;
                 additionalData = data;
-                return true;
+                return new ProcessData(ProcessDataState.Processed);
             }
 
             var loggerZvtCommunication = LoggerHelper.GetLogger<ZvtCommunication>();

--- a/src/Portalum.Zvt/Helpers/PackageHelper.cs
+++ b/src/Portalum.Zvt/Helpers/PackageHelper.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Portalum.Zvt.Helpers
+{
+    public static class PackageHelper
+    {
+        public static byte[] Create(
+            byte[] controlField,
+            IEnumerable<byte> packageData)
+        {
+            var data = packageData.ToArray();
+
+            using var memoryStream = new MemoryStream();
+            memoryStream.Write(controlField, 0, controlField.Length);
+            memoryStream.WriteByte((byte)data.Length);
+            memoryStream.Write(data, 0, data.Length);
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/src/Portalum.Zvt/IReceiveHandler.cs
+++ b/src/Portalum.Zvt/IReceiveHandler.cs
@@ -43,6 +43,6 @@ namespace Portalum.Zvt
         /// </summary>
         /// <param name="data"></param>
         /// <returns></returns>
-        ProcessDataState ProcessData(Span<byte> data);
+        ProcessData ProcessData(Span<byte> data);
     }
 }

--- a/src/Portalum.Zvt/Models/Abort.cs
+++ b/src/Portalum.Zvt/Models/Abort.cs
@@ -1,0 +1,12 @@
+using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models
+{
+    public class Abort : IResponse,
+        IResponseErrorCode,
+        IResponseErrorMessage
+    {
+        public byte ErrorCode { get; set; }
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/Models/Completion.cs
+++ b/src/Portalum.Zvt/Models/Completion.cs
@@ -1,0 +1,8 @@
+using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models
+{
+    public class Completion : IResponse
+    {
+    }
+}

--- a/src/Portalum.Zvt/Models/CompletionInfo.cs
+++ b/src/Portalum.Zvt/Models/CompletionInfo.cs
@@ -1,0 +1,23 @@
+﻿namespace Portalum.Zvt.Models
+{
+    public class CompletionInfo
+    {
+        /// <summary>
+        /// Status of the issue goods operation
+        /// </summary>
+        public CompletionInfoState State { get; set; } = CompletionInfoState.Wait;
+
+        /// <summary>
+        /// The amount to finally charge the customer. If only a partial issue of goods was possible, a lower than
+        /// initially authorized amount can be used.
+        /// </summary>
+        public decimal Amount { get; set; }
+
+        public CompletionInfo() : this(CompletionInfoState.Wait) { }
+
+        public CompletionInfo(CompletionInfoState state)
+        {
+            this.State = state;
+        }
+    }
+}

--- a/src/Portalum.Zvt/Models/CompletionInfoState.cs
+++ b/src/Portalum.Zvt/Models/CompletionInfoState.cs
@@ -1,0 +1,28 @@
+﻿namespace Portalum.Zvt.Models
+{
+    /// <summary>
+    /// Status of the issue goods operation
+    /// </summary>
+    public enum CompletionInfoState
+    {
+        /// <summary>
+        /// This status keeps the issue goods operation in progress and delays the timeout at the payment terminal
+        /// </summary>
+        Wait,
+
+        /// <summary>
+        /// The amount specified in the CompletionInfoStatus is used to change the final amount of the payment 
+        /// </summary>
+        ChangeAmount,
+
+        /// <summary>
+        /// The operation was successful and the amount initially authorized will be charged
+        /// </summary>
+        Successful,
+
+        /// <summary>
+        /// The operation failed and an auto reversal is triggered
+        /// </summary>
+        Failure
+    }
+}

--- a/src/Portalum.Zvt/Models/IntermediateStatusInformation.cs
+++ b/src/Portalum.Zvt/Models/IntermediateStatusInformation.cs
@@ -1,0 +1,10 @@
+using Portalum.Zvt.Repositories;
+using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models
+{
+    public class IntermediateStatusInformation : IResponse, IResponseErrorMessage
+    {
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/Models/PrintLineInfo.cs
+++ b/src/Portalum.Zvt/Models/PrintLineInfo.cs
@@ -1,9 +1,11 @@
-﻿namespace Portalum.Zvt.Models
+﻿using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models
 {
     /// <summary>
     /// Print LineInfo
     /// </summary>
-    public class PrintLineInfo
+    public class PrintLineInfo : IResponse
     {
         /// <summary>
         /// Is text centred

--- a/src/Portalum.Zvt/Models/PrintTextBlock.cs
+++ b/src/Portalum.Zvt/Models/PrintTextBlock.cs
@@ -1,0 +1,9 @@
+using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models
+{
+    public class PrintTextBlock : IResponse
+    {
+        
+    }
+}

--- a/src/Portalum.Zvt/Models/ProcessData.cs
+++ b/src/Portalum.Zvt/Models/ProcessData.cs
@@ -1,0 +1,30 @@
+using Portalum.Zvt.Responses;
+
+namespace Portalum.Zvt.Models;
+
+/// <summary>
+/// a class describing the result of the IReceiveHandler's data processing
+/// </summary>
+public class ProcessData
+{
+    /// <summary>
+    /// Current State of the data processing
+    /// </summary>
+    public ProcessDataState State { get; set; }
+
+    /// <summary>
+    /// Current State of the data processing
+    /// </summary>
+    public IResponse Response { get; set; } = null;
+
+    public ProcessData(ProcessDataState state)
+    {
+        this.State = state;
+    }
+
+    public ProcessData(ProcessDataState state, IResponse response)
+    {
+        this.State = state;
+        this.Response = response;
+    }
+}

--- a/src/Portalum.Zvt/Models/StatusInformation.cs
+++ b/src/Portalum.Zvt/Models/StatusInformation.cs
@@ -6,6 +6,7 @@ namespace Portalum.Zvt.Models
     public class StatusInformation :
         IResponse,
         IResponseErrorMessage,
+        IResponseErrorCode,
         IResponseAdditionalText,
         IResponseTerminalIdentifier,
         IResponseAmount,
@@ -44,5 +45,6 @@ namespace Portalum.Zvt.Models
         public int CardSequenceNumber { get; set; }
         public int TurnoverRecordNumber { get; set; }
         public string CardType { get; set; }
+        public byte ErrorCode { get; set; }
     }
 }

--- a/src/Portalum.Zvt/Models/StatusInformation.cs
+++ b/src/Portalum.Zvt/Models/StatusInformation.cs
@@ -23,7 +23,8 @@ namespace Portalum.Zvt.Models
         IResponseExpiryDate,
         IResponseCardSequenceNumber,
         IResponseTurnoverRecordNumber,
-        IResponseCardType
+        IResponseCardType,
+        IResponseCardNumber
     {
         public string ErrorMessage { get; set; }
         public int TerminalIdentifier { get; set; }
@@ -46,5 +47,6 @@ namespace Portalum.Zvt.Models
         public int TurnoverRecordNumber { get; set; }
         public string CardType { get; set; }
         public byte ErrorCode { get; set; }
+        public string CardNumber { get; set; }
     }
 }

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -290,7 +290,7 @@ namespace Portalum.Zvt.Parsers
                 new BmpInfo { Id = 0x0E, DataLength = 2, Description = "Expiry-date, format YYMM", TryParse = this.ParseExpiryDate },
                 new BmpInfo { Id = 0x17, DataLength = 2, Description = "Card sequence-number", TryParse = this.ParseCardSequenceNumber },
                 new BmpInfo { Id = 0x19, DataLength = 1, Description = "Status-byte as defined in Registration (06 00) / Payment-type as defined in Authorization (06 01) / Card-type as defined in Read Card (06 C0)", TryParse = null },
-                new BmpInfo { Id = 0x22, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "PAN / EF_ID, 'E' used to indicate a masked numeric digit1. If the card-number contains an odd number of digits, it is padded with an ‘F’.", TryParse = null },
+                new BmpInfo { Id = 0x22, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "PAN / EF_ID, 'E' used to indicate a masked numeric digit1. If the card-number contains an odd number of digits, it is padded with an ‘F’.", TryParse = ParsePanData },
                 new BmpInfo { Id = 0x23, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "Track 2 data, without start and end markers; 'E' used to indicate a masked numeric digit", TryParse = null },
                 new BmpInfo { Id = 0x24, DataLength = 3, CalculateDataLength = this.GetDataLengthLLL, Description = "Track 3 data, without start and end markers; 'E' used to indicate a masked numeric digit", TryParse = null },
                 new BmpInfo { Id = 0x27, DataLength = 1, Description = "Result-Code as defined in chapter Error-Messages", TryParse = this.ParseErrorCode },
@@ -735,7 +735,17 @@ namespace Portalum.Zvt.Parsers
 
             return false;
         }
-
+        
+        private bool ParsePanData(byte[] data, IResponse response)
+        {
+            if (response is IResponseCardNumber typedResponse)
+            {
+                var cardNumber = BitConverter.ToString(data).Replace("-", "").Replace("E", "");
+                typedResponse.CardNumber = cardNumber;
+                return true;
+            }
+            return false;
+        }
         private bool ParseCardName(byte[] data, IResponse response)
         {
             if (response is IResponseCardName typedResponse)

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -740,7 +740,10 @@ namespace Portalum.Zvt.Parsers
         {
             if (response is IResponseCardNumber typedResponse)
             {
-                var cardNumber = BitConverter.ToString(data).Replace("-", "").Replace("E", "");
+                var cardNumber = BitConverter.ToString(data)
+                    .Replace("F", "")
+                    .Replace("-", "")
+                    .Replace("E", "*");
                 typedResponse.CardNumber = cardNumber;
                 return true;
             }

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -506,14 +506,21 @@ namespace Portalum.Zvt.Parsers
         private bool ParseErrorCode(byte[] data, IResponse response)
         {
             var errorMessage = this._errorMessageRepository.GetMessage(data[0]);
-
-            if (response is IResponseErrorMessage typedResponse)
+            bool parsed = false;
+            
+            if (response is IResponseErrorMessage typedErrorMessageResponse)
             {
-                typedResponse.ErrorMessage = errorMessage;
-                return true;
+                typedErrorMessageResponse.ErrorMessage = errorMessage;
+                parsed = true;
+            }
+            
+            if (response is IResponseErrorCode typedErrorCodeResponse)
+            {
+                typedErrorCodeResponse.ErrorCode = data[0];
+                parsed = true;
             }
 
-            return false;
+            return parsed;
         }
 
         private bool ParseTime(byte[] data, IResponse response)

--- a/src/Portalum.Zvt/Responses/IResponseCardNumber.cs
+++ b/src/Portalum.Zvt/Responses/IResponseCardNumber.cs
@@ -1,0 +1,7 @@
+﻿namespace Portalum.Zvt.Responses
+{
+    public interface IResponseCardNumber
+    {
+        string CardNumber { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/Responses/IResponseErrorCode.cs
+++ b/src/Portalum.Zvt/Responses/IResponseErrorCode.cs
@@ -1,0 +1,7 @@
+namespace Portalum.Zvt.Responses
+{
+    public interface IResponseErrorCode
+    {
+        byte ErrorCode { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -5,6 +5,7 @@ using Portalum.Zvt.Models;
 using Portalum.Zvt.Repositories;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -30,6 +31,7 @@ namespace Portalum.Zvt
         private readonly ZvtCommunication _zvtCommunication;
         private IReceiveHandler _receiveHandler;
         private readonly TimeSpan _commandCompletionTimeout;
+        private readonly ZvtClientConfig _clientConfig;
 
         #region Events
 
@@ -52,6 +54,20 @@ namespace Portalum.Zvt
         /// Receive a full receipt at once
         /// </summary>
         public event Action<ReceiptInfo> ReceiptReceived;
+
+        /// <summary>
+        /// When the event is registered it is queries periodically to check if the issue of goods is finished.
+        /// Upon successful completion the payment is stored, otherwise an auto reversal is triggered.
+        /// For possible return values see CompletionInfoStatus.
+        /// </summary>
+        public event Func<CompletionInfo> GetAsyncCompletionInfo;
+
+        /// <summary>
+        /// Raised when the payment was successful, but before it is stored in the PT. After this event the GetAsyncCompletionInfo
+        /// callback is queries periodically to obtain the completion status. If GetAsyncCompleteInfo is not registered the payment
+        /// is stored immediately in the PT and this event is never raised.
+        /// </summary>
+        public event Action<StatusInformation> StartAsyncCompletion;
 
         #endregion
 
@@ -82,6 +98,7 @@ namespace Portalum.Zvt
             this._commandCompletionTimeout = clientConfig.CommandCompletionTimeout;
 
             this._passwordData = NumberHelper.IntToBcd(clientConfig.Password);
+            this._clientConfig = clientConfig;
 
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
@@ -101,6 +118,7 @@ namespace Portalum.Zvt
 
             this._zvtCommunication = new ZvtCommunication(logger, deviceCommunication);
             this._zvtCommunication.DataReceived += this.DataReceived;
+            this._zvtCommunication.GetCompletionInfo += GetCompletionInfo;
         }
 
         /// <inheritdoc />
@@ -119,10 +137,16 @@ namespace Portalum.Zvt
             if (disposing)
             {
                 this._zvtCommunication.DataReceived -= this.DataReceived;
+                this._zvtCommunication.GetCompletionInfo -= this.GetCompletionInfo;
                 this._zvtCommunication.Dispose();
 
                 this.UnregisterReceiveHandlerEvents();
             }
+        }
+
+        private CompletionInfo GetCompletionInfo()
+        {
+            return this.GetAsyncCompletionInfo?.Invoke();
         }
 
         private Encoding GetEncoding(ZvtEncoding zvtEncoding)
@@ -182,7 +206,7 @@ namespace Portalum.Zvt
             {
                 return new GermanIntermediateStatusRepository();
             }
-            
+
             return new EnglishIntermediateStatusRepository();
         }
 
@@ -206,23 +230,26 @@ namespace Portalum.Zvt
             this.ReceiptReceived?.Invoke(receiptInfo);
         }
 
-        private bool DataReceived(byte[] data)
+        private ProcessData DataReceived(byte[] data)
         {
-            var processDataState = this._receiveHandler.ProcessData(data);
-            switch (processDataState)
+            var processData = this._receiveHandler.ProcessData(data);
+            switch (processData.State)
             {
                 case ProcessDataState.CannotProcess:
                 case ProcessDataState.ParseFailure:
                     this._logger.LogError($"{nameof(DataReceived)} - Unprocessable data received {BitConverter.ToString(data)}");
-                    return false;
+                    break;
+
                 case ProcessDataState.WaitForMoreData:
-                    return false;
                 case ProcessDataState.Processed:
-                    return true;
+                    break;
+
+                default:
+                    this._logger.LogCritical($"{nameof(DataReceived)} - Invalid state {processData.State}");
+                    break;
             }
 
-            this._logger.LogCritical($"{nameof(DataReceived)} - Invalid state {processDataState}");
-            return false;
+            return processData;
         }
 
         /// <summary>
@@ -238,8 +265,11 @@ namespace Portalum.Zvt
             CancellationToken cancellationToken = default)
         {
             using var timeoutCancellationTokenSource = new CancellationTokenSource(this._commandCompletionTimeout);
-            using var dataReceivcedCancellationTokenSource = new CancellationTokenSource();
-            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dataReceivcedCancellationTokenSource.Token, timeoutCancellationTokenSource.Token);
+            using var dataReceivedCancellationTokenSource = new CancellationTokenSource();
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dataReceivedCancellationTokenSource.Token, timeoutCancellationTokenSource.Token);
+
+            var isAsyncCompletion = this.GetAsyncCompletionInfo != null;
+            var startAsyncCompletionFired = false;
 
             var commandResponse = new CommandResponse
             {
@@ -250,7 +280,7 @@ namespace Portalum.Zvt
             {
                 commandResponse.State = CommandResponseState.Successful;
 
-                dataReceivcedCancellationTokenSource.Cancel();
+                dataReceivedCancellationTokenSource.Cancel();
             }
 
             void abortReceived(string errorMessage)
@@ -258,7 +288,7 @@ namespace Portalum.Zvt
                 commandResponse.State = CommandResponseState.Abort;
                 commandResponse.ErrorMessage = errorMessage;
 
-                dataReceivcedCancellationTokenSource.Cancel();
+                dataReceivedCancellationTokenSource.Cancel();
             }
 
             void intermediateStatusInformationReceived(string status)
@@ -269,6 +299,12 @@ namespace Portalum.Zvt
             void statusInformationReceived(StatusInformation statusInformation)
             {
                 timeoutCancellationTokenSource.CancelAfter(this._commandCompletionTimeout);
+
+                if (statusInformation.ErrorCode == 0 && isAsyncCompletion && !startAsyncCompletionFired)
+                {
+                    startAsyncCompletionFired = true;
+                    this.StartAsyncCompletion?.Invoke(statusInformation);
+                }
             }
 
             try
@@ -289,7 +325,7 @@ namespace Portalum.Zvt
                 }
                 if (sendCommandResult != SendCommandResult.PositiveCompletionReceived)
                 {
-                    this._logger.LogError($"{nameof(SendCommandAsync)} - Failure on send command {sendCommandResult}");
+                    this._logger.LogError($"{nameof(SendCommandAsync)} - Failure on send command: {sendCommandResult}");
                     commandResponse.State = CommandResponseState.Error;
                     commandResponse.ErrorMessage = sendCommandResult.ToString();
 
@@ -321,156 +357,6 @@ namespace Portalum.Zvt
             }
 
             return commandResponse;
-        }
-
-
-        /// <summary>
-        /// SendCommandAsync
-        /// </summary>
-        /// <param name="commandData">The data of the command</param>
-        /// <param name="callback">A callback which is started after receiving a positive StatusInformation. The answer to StatusInformation is delayed until the end of the task or a timeout occurs.</param>
-        /// <param name="endAfterAcknowledge">After receive an acknowledge the command is successful</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        private async Task<CommandResponse> SendCommandAsyncWithCallback(
-            byte[] commandData,
-            Func<Task<bool>> callback,
-            TimeSpan callbackTimeout,
-            bool endAfterAcknowledge = false,
-            CancellationToken cancellationToken = default
-        )
-        {
-            using var timeoutCancellationTokenSource = new CancellationTokenSource(this._commandCompletionTimeout);
-            using var callbackTimeoutCancellationTokenSource = new CancellationTokenSource(_commandCompletionTimeout);
-            using var dataReceivedCancellationTokenSource = new CancellationTokenSource();
-            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken,
-                dataReceivedCancellationTokenSource.Token, timeoutCancellationTokenSource.Token);
-
-            Task<bool> callbackTask = null;
-
-            var commandResponse = new CommandResponse
-            {
-                State = CommandResponseState.Unknown
-            };
-
-            void completionReceived()
-            {
-                commandResponse.State = CommandResponseState.Successful;
-
-                dataReceivedCancellationTokenSource.Cancel();
-            }
-
-            void abortReceived(string errorMessage)
-            {
-                commandResponse.State = CommandResponseState.Abort;
-                commandResponse.ErrorMessage = errorMessage;
-
-                dataReceivedCancellationTokenSource.Cancel();
-            }
-
-            void intermediateStatusInformationReceived(string status)
-            {
-                timeoutCancellationTokenSource.CancelAfter(this._commandCompletionTimeout);
-            }
-
-            void statusInformationReceived(StatusInformation statusInformation)
-            {
-                if (callback != null && statusInformation.ErrorCode == 0)
-                {
-                    if (callbackTask == null)
-                    {
-                        this._zvtCommunication.suppressAcknowledge = true;
-                        callbackTimeoutCancellationTokenSource.CancelAfter(callbackTimeout);
-                        callbackTask = Task.Run(callback, callbackTimeoutCancellationTokenSource.Token);
-                        callbackTask.ContinueWith(task =>
-                        {
-                            if (callbackTimeoutCancellationTokenSource.IsCancellationRequested)
-                            {
-                                this._zvtCommunication.SendAcknowledgement(false);
-                            }
-                            else
-                            {
-                                this._zvtCommunication.SendAcknowledgement(task.Result);
-                            }
-                            this._zvtCommunication.suppressAcknowledge = false;
-                        });
-                    }
-                    else
-                    {
-                        this._logger.LogWarning("An additional StatusInformation was received. " +
-                                                "The callback task is already running.");
-                    }
-                }
-
-                timeoutCancellationTokenSource.CancelAfter(this._commandCompletionTimeout);
-            }
-
-            try
-            {
-                this._receiveHandler.CompletionReceived += completionReceived;
-                this._receiveHandler.AbortReceived += abortReceived;
-                this._receiveHandler.IntermediateStatusInformationReceived += intermediateStatusInformationReceived;
-                this._receiveHandler.StatusInformationReceived += statusInformationReceived;
-
-                this._logger.LogDebug($"{nameof(SendCommandAsync)} - Send command to PT");
-
-                var sendCommandResult =
-                    await this._zvtCommunication.SendCommandAsync(commandData, cancellationToken: cancellationToken);
-                if (sendCommandResult == SendCommandResult.NotSupported)
-                {
-                    this._logger.LogError($"{nameof(SendCommandAsync)} - NotSupported");
-                    commandResponse.State = CommandResponseState.NotSupported;
-                    return commandResponse;
-                }
-
-                if (sendCommandResult != SendCommandResult.PositiveCompletionReceived)
-                {
-                    this._logger.LogError($"{nameof(SendCommandAsync)} - Failure on send command {sendCommandResult}");
-                    commandResponse.State = CommandResponseState.Error;
-                    commandResponse.ErrorMessage = sendCommandResult.ToString();
-
-                    return commandResponse;
-                }
-
-                if (endAfterAcknowledge)
-                {
-                    commandResponse.State = CommandResponseState.Successful;
-                    return commandResponse;
-                }
-
-                // There is no infinite timeout here, the timeout comes via the `timeoutCancellationTokenSource`
-                await Task.Delay(Timeout.InfiniteTimeSpan, linkedCancellationTokenSource.Token).ContinueWith(task =>
-                {
-                    if (timeoutCancellationTokenSource.IsCancellationRequested)
-                    {
-                        commandResponse.State = CommandResponseState.Timeout;
-                        this._logger.LogError(
-                            $"{nameof(SendCommandAsync)} - No result received in the specified timeout {this._commandCompletionTimeout.TotalMilliseconds}ms");
-                    }
-                });
-            }
-            finally
-            {
-                this._receiveHandler.AbortReceived -= abortReceived;
-                this._receiveHandler.CompletionReceived -= completionReceived;
-                this._receiveHandler.IntermediateStatusInformationReceived -= intermediateStatusInformationReceived;
-                this._receiveHandler.StatusInformationReceived -= statusInformationReceived;
-                this._zvtCommunication.suppressAcknowledge = false;
-            }
-
-            return commandResponse;
-        }
-
-
-        private byte[] CreatePackage(
-            byte[] controlField,
-            IEnumerable<byte> packageData)
-        {
-            var package = new List<byte>();
-            package.AddRange(controlField);
-            package.Add((byte)packageData.Count());
-            package.AddRange(packageData);
-            return package.ToArray();
         }
 
         /// <summary>
@@ -537,7 +423,7 @@ namespace Portalum.Zvt
                 //1F05 - Transaction parameter
             }
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x00 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x00 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -547,14 +433,10 @@ namespace Portalum.Zvt
         /// </summary>
         /// <param name="amount"></param>
         /// <param name="cancellationToken"></param>
-        /// <param name="issueGoodsCallback">A optional task which is started after the payment was successful. If the task returns true within issueGoodsTimeout seconds the payment is accepted. Otherwise the PT triggers an auto-reversal.</param>
-        /// <param name="issueGoodsTimeout">Supplies the time in seconds that the PT waits during issue of goods for a response from the ECR. The default value is 30 seconds.</param>
         /// <returns></returns>
         public async Task<CommandResponse> PaymentAsync(
             decimal amount,
-            CancellationToken cancellationToken = default,
-            Func<Task<bool>> issueGoodsCallback = null,
-            decimal? issueGoodsTimeout = null)
+            CancellationToken cancellationToken = default)
         {
             this._logger.LogInformation($"{nameof(PaymentAsync)} - Execute with amount of:{amount}");
 
@@ -562,30 +444,14 @@ namespace Portalum.Zvt
             package.Add(0x04); //Amount prefix
             package.AddRange(NumberHelper.DecimalToBcd(amount));
 
-            if (issueGoodsTimeout != null)
+            if (this.GetAsyncCompletionInfo != null)
             {
-                package.Add(0x01); //timeout prefix
-                package.AddRange(NumberHelper.DecimalToBcd((decimal)issueGoodsTimeout / 100, length: 1));
-            }
-            else
-            {
-                issueGoodsTimeout = 30;
+                package.Add(0x02); // max nr. of status-informations
+                package.Add(this._clientConfig.GetAsyncCompletionInfoLimit);
             }
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x01 }, package);
-
-            if (issueGoodsCallback != null)
-            {
-                return await this.SendCommandAsyncWithCallback(fullPackage,
-                    cancellationToken: cancellationToken,
-                    callback: issueGoodsCallback,
-                    callbackTimeout: TimeSpan.FromSeconds((double)issueGoodsTimeout)
-                );
-            }
-            else
-            {
-                return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
-            }
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x01 }, package);
+            return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -607,7 +473,7 @@ namespace Portalum.Zvt
             package.Add(0x87); //ReceiptNumber prefix
             package.AddRange(NumberHelper.IntToBcd(receiptNumber, 2));
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x30 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x30 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -629,7 +495,7 @@ namespace Portalum.Zvt
             package.Add(0x04); //Amount prefix
             package.AddRange(NumberHelper.DecimalToBcd(amount));
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x31 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x31 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -646,7 +512,7 @@ namespace Portalum.Zvt
             var package = new List<byte>();
             package.AddRange(this._passwordData);
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x50 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x50 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -663,7 +529,7 @@ namespace Portalum.Zvt
             var package = new List<byte>();
             package.AddRange(this._passwordData);
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x10 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x10 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -680,7 +546,7 @@ namespace Portalum.Zvt
             var package = new List<byte>();
             package.AddRange(this._passwordData);
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x20 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x20 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -695,7 +561,7 @@ namespace Portalum.Zvt
 
             var package = Array.Empty<byte>();
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x02 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x02 }, package);
             return await this.SendCommandAsync(fullPackage, endAfterAcknowledge: true, cancellationToken: cancellationToken);
         }
 
@@ -710,7 +576,7 @@ namespace Portalum.Zvt
 
             var package = Array.Empty<byte>();
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0xB0 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0xB0 }, package);
             return await this.SendCommandAsync(fullPackage, endAfterAcknowledge: true, cancellationToken: cancellationToken);
         }
 
@@ -725,7 +591,7 @@ namespace Portalum.Zvt
 
             var package = Array.Empty<byte>();
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x06, 0x70 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x70 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -740,7 +606,7 @@ namespace Portalum.Zvt
 
             var package = Array.Empty<byte>();
 
-            var fullPackage = this.CreatePackage(new byte[] { 0x08, 0x10 }, package);
+            var fullPackage = PackageHelper.Create(new byte[] { 0x08, 0x10 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
 
@@ -763,7 +629,7 @@ namespace Portalum.Zvt
                 packageData = Array.Empty<byte>();
             }
 
-            var fullPackage = this.CreatePackage(controlFieldData, packageData);
+            var fullPackage = PackageHelper.Create(controlFieldData, packageData);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);
         }
     }

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -82,7 +82,8 @@ namespace Portalum.Zvt
             IDeviceCommunication deviceCommunication,
             ILogger<ZvtClient> logger = default,
             ZvtClientConfig clientConfig = default,
-            IReceiveHandler receiveHandler = default)
+            IReceiveHandler receiveHandler = default,
+            ZvtCommunication zvtCommunication = default)
         {
             if (logger == null)
             {
@@ -116,7 +117,14 @@ namespace Portalum.Zvt
 
             #endregion
 
-            this._zvtCommunication = new ZvtCommunication(logger, deviceCommunication);
+            if( zvtCommunication == default)
+            {
+                this._zvtCommunication = new ZvtCommunication(logger, deviceCommunication);
+            }
+            else
+            {
+                this._zvtCommunication = zvtCommunication;
+            }
             this._zvtCommunication.DataReceived += this.DataReceived;
             this._zvtCommunication.GetCompletionInfo += GetCompletionInfo;
         }

--- a/src/Portalum.Zvt/ZvtClientConfig.cs
+++ b/src/Portalum.Zvt/ZvtClientConfig.cs
@@ -26,5 +26,13 @@ namespace Portalum.Zvt
         /// Timeout after Command Acknowledge and Completion
         /// </summary>
         public TimeSpan CommandCompletionTimeout = TimeSpan.FromSeconds(180);
+
+        
+        /// <summary>
+        /// Maximum number of times the AskForCompletionInfo callback is called. After this number of
+        /// times a auto reversal will be triggered and the payment will fail. A PT usually queries
+        /// every 2 (ZVT standard) to 4 (observed in practice) seconds for the completion status.
+        /// </summary>
+        public byte GetAsyncCompletionInfoLimit = 100;
     }
 }

--- a/src/Portalum.Zvt/ZvtCommunication.cs
+++ b/src/Portalum.Zvt/ZvtCommunication.cs
@@ -15,12 +15,12 @@ namespace Portalum.Zvt
     /// </summary>
     public class ZvtCommunication : IDisposable
     {
-        private readonly ILogger _logger;
-        private readonly IDeviceCommunication _deviceCommunication;
+        protected readonly ILogger _logger;
+        protected readonly IDeviceCommunication _deviceCommunication;
 
-        private CancellationTokenSource _acknowledgeReceivedCancellationTokenSource;
-        private byte[] _dataBuffer;
-        private bool _waitForAcknowledge = false;
+        protected CancellationTokenSource _acknowledgeReceivedCancellationTokenSource;
+        protected byte[] _dataBuffer;
+        protected bool _waitForAcknowledge = false;
 
         /// <summary>
         /// New data received from the pt device
@@ -32,12 +32,12 @@ namespace Portalum.Zvt
         /// </summary>
         public event Func<CompletionInfo> GetCompletionInfo;
 
-        private readonly byte[] _positiveCompletionData1 = new byte[] { 0x80, 0x00, 0x00 }; //Default
-        private readonly byte[] _positiveCompletionData2 = new byte[] { 0x84, 0x00, 0x00 }; //Alternative
-        private readonly byte[] _positiveCompletionData3 = new byte[] { 0x84, 0x9C, 0x00 }; //Special case for request more time
-        private readonly byte[] _negativeIssueGoodsData = new byte[] { 0x84, 0x66, 0x00 };
-        private readonly byte[] _otherCommandData = new byte[] { 0x84, 0x83, 0x00 };
-        private readonly byte _negativeCompletionPrefix = 0x84;
+        protected readonly byte[] _positiveCompletionData1 = new byte[] { 0x80, 0x00, 0x00 }; //Default
+        protected readonly byte[] _positiveCompletionData2 = new byte[] { 0x84, 0x00, 0x00 }; //Alternative
+        protected readonly byte[] _positiveCompletionData3 = new byte[] { 0x84, 0x9C, 0x00 }; //Special case for request more time
+        protected readonly byte[] _negativeIssueGoodsData = new byte[] { 0x84, 0x66, 0x00 };
+        protected readonly byte[] _otherCommandData = new byte[] { 0x84, 0x83, 0x00 };
+        protected readonly byte _negativeCompletionPrefix = 0x84;
 
         /// <summary>
         /// ZvtCommunication

--- a/src/Portalum.Zvt/ZvtCommunication.cs
+++ b/src/Portalum.Zvt/ZvtCommunication.cs
@@ -76,7 +76,7 @@ namespace Portalum.Zvt
         /// Switch for incoming data
         /// </summary>
         /// <param name="data"></param>
-        private void DataReceiveSwitch(byte[] data)
+        protected virtual void DataReceiveSwitch(byte[] data)
         {
             if (this._waitForAcknowledge)
             {
@@ -87,13 +87,13 @@ namespace Portalum.Zvt
             this.ProcessData(data);
         }
 
-        private void AddDataToBuffer(byte[] data)
+        protected virtual void AddDataToBuffer(byte[] data)
         {
             this._dataBuffer = data;
             this._acknowledgeReceivedCancellationTokenSource?.Cancel();
         }
 
-        private void ProcessData(byte[] data)
+        protected virtual void ProcessData(byte[] data)
         {
             var dataProcessed = this.DataReceived?.Invoke(data);
             if (dataProcessed?.State == ProcessDataState.Processed)
@@ -209,7 +209,7 @@ namespace Portalum.Zvt
             return SendCommandResult.UnknownFailure;
         }
 
-        private bool CheckIsPositiveCompletion()
+        protected virtual bool CheckIsPositiveCompletion()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -236,7 +236,7 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private bool CheckIsNegativeCompletion()
+        protected virtual bool CheckIsNegativeCompletion()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -254,7 +254,7 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private bool CheckIsNotSupported()
+        protected virtual bool CheckIsNotSupported()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -271,12 +271,12 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private void ResetDataBuffer()
+        protected virtual void ResetDataBuffer()
         {
             this._dataBuffer = null;
         }
 
-        private void ForwardUnusedBufferData()
+        protected virtual void ForwardUnusedBufferData()
         {
             if (this._dataBuffer.Length == 3)
             {


### PR DESCRIPTION
## Why
Any unattended ECR has the problem where it has to decide if it finishes the transaction with the payment terminal first, and then issues the goods to the customer, or vice versa. For vending machines with mechanical parts, or other cash registers where the failure is an option the workflow according to the ZVT standard is, that the goods are issued first and only then the transaction is finalized in the PT. If the issuing of goods fails, an auto reversal is triggered. This is essential in unattended use cases (compared to attended ones) because the card does not need to be presented again to the PT.

For us such failures are an option and the current implementation does not support a callback for issuing goods. This PR is a proposal to implement such a callback. I am unfamiliar with async c#, and other deep details of the library, so it might not be the best solution, but as it stands the implementation works. We have tested it with Worldline Valina Payment Terminals (Card Complete). 

I am perfectly happy with maintaining a fork, but i think this function is a great addition to the library, in order to ensure that customers always get their goods :)

## Caveats and Missing parts

* The callback timeout and the command timeout does not cooperate in any way
* The implementation does not send timeout extension messages (0x84, 0x9C, 0x00) in order to extend the timeout. This, and the point above limits the timeouts to at most the command timeout.
* Its currently only tested with one terminal, and only with TCP mode

## Experiments

**Worldline Valina (Card Complete)**: 
Observations:
* The terminal sends a second StatusInformation (with error-code = 0, i.e. success) after the timeout but continues to function
* only after about 2.5-3.0 times the timeout it sends an Abort message

this fact led me to cancel the callback after the timeout, because otherwise we do not exactly know when a timeout will occur.

## Testing

I have added a couple of test cases to ensure the basic functionality. For testing you can use one of the snippets. Those will trigger an auto reversal.

* explicitly fail
  ```c#
  async Task<bool> callback(){ await Task.Delay(3000); return false; }
  await zvtClient.PaymentAsync(0.1m, issueGoodsTimeout:5, issueGoodsCallback:callback);
  ```

* time out
  ```c#
  async Task<bool> callback(){ await Task.Delay(10000); return true; }
  await zvtClient.PaymentAsync(0.1m, issueGoodsTimeout:5, issueGoodsCallback:callback);
  ```

This will succeed, but take a long time:

```c#
async Task<bool> callback(){ await Task.Delay(15000); return true; }
await zvtClient.PaymentAsync(0.1m, issueGoodsTimeout:20, issueGoodsCallback:callback);
```

