### PR TITLE
fixes a testcase for systems where newline is not CRLF

### DIFF
--- a/src/Portalum.Zvt.UnitTest/IntermediateStatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/IntermediateStatusInformationParserTest.cs
@@ -51,8 +51,12 @@ namespace Portalum.Zvt.UnitTest
         {
             var parser = this.GetIntermediateStatusInformationParser();
             var statusMessage = parser.GetMessage(new byte[] { 0xFF, 0x10, 0x06, 0x1A, 0x24, 0x18, 0x07, 0x08, 0x45, 0x55, 0x52, 0x20, 0x31, 0x2E, 0x32, 0x33, 0x07, 0x0C, 0x42, 0x69, 0x74, 0x74, 0x65, 0x20, 0x77, 0x61, 0x72, 0x74, 0x65, 0x6E });
-
-            Assert.AreEqual("EUR 1.23\r\nBitte warten\r\n", statusMessage);
+            
+            var expectedMessage = new StringBuilder();
+            expectedMessage.AppendLine("EUR 1.23");
+            expectedMessage.AppendLine("Bitte warten");
+            
+            Assert.AreEqual(expectedMessage.ToString(), statusMessage);
         }
     }
 }


### PR DESCRIPTION
This just fixes testcases on unix systems, where CRLF is not the newline separator. 