### PR TITLE
support receipt generation by the ECR

### DIFF
--- a/src/Portalum.Zvt.UnitTest/RegistrationConfigTest.cs
+++ b/src/Portalum.Zvt.UnitTest/RegistrationConfigTest.cs
@@ -31,5 +31,28 @@ namespace Portalum.Zvt.UnitTest
 
             Assert.AreEqual(0x03, serviceByte);
         }
+        
+        [TestMethod]
+        public void GetServiceByte_GetConfigByte1_Successful()
+        {
+            var registrationConfig = new RegistrationConfig
+            {
+                ReceiptPrintoutGeneratedViaPaymentTerminal = false
+            };
+
+            var serviceByte = registrationConfig.GetConfigByte();
+
+            Assert.AreEqual(0x36, serviceByte);
+        }
+        
+        [TestMethod]
+        public void GetServiceByte_GetConfigByte2_Successful()
+        {
+            var registrationConfig = new RegistrationConfig { };
+
+            var configByte = registrationConfig.GetConfigByte();
+
+            Assert.AreEqual(0xB6, configByte);
+        }
     }
 }

--- a/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Portalum.Zvt.Helpers;
 using Portalum.Zvt.Parsers;
 using Portalum.Zvt.Repositories;
@@ -31,6 +33,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("Abbruch durch Kunde", statusInformation.AdditionalText);
+            Assert.AreEqual(0x6C, statusInformation.ErrorCode);
             Assert.AreEqual("abort via timeout or abort-key", statusInformation.ErrorMessage);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
         }
@@ -47,6 +50,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("Betrag falsch", statusInformation.AdditionalText);
+            Assert.AreEqual(0xFF, statusInformation.ErrorCode);
             Assert.AreEqual("system error (= other/unknown error), See TLV tags 1F16 and 1F17", statusInformation.ErrorMessage);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
         }
@@ -73,6 +77,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual(1, statusInformation.CardSequenceNumber);
             Assert.AreEqual(new TimeSpan(22, 39, 53), statusInformation.Time);
             Assert.AreEqual(28004869, statusInformation.TerminalIdentifier);
+            Assert.AreEqual("************4771", statusInformation.CardNumber);
         }
 
         [TestMethod]
@@ -126,6 +131,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual("MASTERCARD", statusInformation.CardName);
             Assert.AreEqual(6, statusInformation.TerminalIdentifier);
             Assert.AreEqual("no error", statusInformation.ErrorMessage);
+            Assert.AreEqual(0, statusInformation.ErrorCode);
             Assert.AreEqual("NFC", statusInformation.CardTechnology);
             Assert.AreEqual("No Cardholder authentication", statusInformation.CardholderAuthentication);
         }
@@ -145,6 +151,7 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual("MASTERCARD", statusInformation.CardName);
             Assert.AreEqual(6, statusInformation.TerminalIdentifier);
             Assert.AreEqual("no error", statusInformation.ErrorMessage);
+            Assert.AreEqual(0, statusInformation.ErrorCode);
             Assert.AreEqual("Chip", statusInformation.CardTechnology);
             Assert.AreEqual("Offline encrypted Pin", statusInformation.CardholderAuthentication);
         }
@@ -162,6 +169,7 @@ namespace Portalum.Zvt.UnitTest
             var statusInformation = statusInformationParser.Parse(data);
 
             Assert.AreEqual("abort via timeout or abort-key", statusInformation.ErrorMessage);
+            Assert.AreEqual(0x6C, statusInformation.ErrorCode);
             Assert.AreEqual(52500295, statusInformation.TerminalIdentifier);
             Assert.AreEqual(12, statusInformation.Amount);
             Assert.AreEqual(978, statusInformation.CurrencyCode);

--- a/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
+++ b/src/Portalum.Zvt.UnitTest/StatusInformationParserTest.cs
@@ -134,6 +134,8 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual(0, statusInformation.ErrorCode);
             Assert.AreEqual("NFC", statusInformation.CardTechnology);
             Assert.AreEqual("No Cardholder authentication", statusInformation.CardholderAuthentication);
+            Assert.AreEqual(29, statusInformation.DateDay);
+            Assert.AreEqual(10, statusInformation.DateMonth);
         }
 
         [TestMethod]
@@ -173,6 +175,8 @@ namespace Portalum.Zvt.UnitTest
             Assert.AreEqual(52500295, statusInformation.TerminalIdentifier);
             Assert.AreEqual(12, statusInformation.Amount);
             Assert.AreEqual(978, statusInformation.CurrencyCode);
+            Assert.AreEqual(17, statusInformation.DateDay);
+            Assert.AreEqual(8, statusInformation.DateMonth);
         }
     }
 }

--- a/src/Portalum.Zvt/Models/StatusInformation.cs
+++ b/src/Portalum.Zvt/Models/StatusInformation.cs
@@ -15,6 +15,7 @@ namespace Portalum.Zvt.Models
         IResponseCardholderAuthentication,
         IResponseCardTechnology,
         IResponseTime,
+        IResponseDate,
         IResponseCurrencyCode,
         IResponseReceiptNumber,
         IResponseTraceNumber,
@@ -48,5 +49,7 @@ namespace Portalum.Zvt.Models
         public int CardSequenceNumber { get; set; }
         public int TurnoverRecordNumber { get; set; }
         public string CardType { get; set; }
+        public int DateMonth { get; set; }
+        public int DateDay { get; set; }
     }
 }

--- a/src/Portalum.Zvt/Models/StatusInformation.cs
+++ b/src/Portalum.Zvt/Models/StatusInformation.cs
@@ -6,10 +6,12 @@ namespace Portalum.Zvt.Models
     public class StatusInformation :
         IResponse,
         IResponseErrorMessage,
+        IResponseErrorCode,
         IResponseAdditionalText,
         IResponseTerminalIdentifier,
         IResponseAmount,
         IResponseCardName,
+        IResponseCardNumber,
         IResponseCardholderAuthentication,
         IResponseCardTechnology,
         IResponseTime,
@@ -25,9 +27,11 @@ namespace Portalum.Zvt.Models
         IResponseCardType
     {
         public string ErrorMessage { get; set; }
+        public byte ErrorCode { get; set; }
         public int TerminalIdentifier { get; set; }
         public string AdditionalText { get; set; }
         public string CardName { get; set; }
+        public string CardNumber { get; set; }
         public decimal Amount { get; set; }
         public string CardholderAuthentication { get; set; }
         public bool PrintoutNeeded { get; set; }

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -290,7 +290,7 @@ namespace Portalum.Zvt.Parsers
                 new BmpInfo { Id = 0x0E, DataLength = 2, Description = "Expiry-date, format YYMM", TryParse = this.ParseExpiryDate },
                 new BmpInfo { Id = 0x17, DataLength = 2, Description = "Card sequence-number", TryParse = this.ParseCardSequenceNumber },
                 new BmpInfo { Id = 0x19, DataLength = 1, Description = "Status-byte as defined in Registration (06 00) / Payment-type as defined in Authorization (06 01) / Card-type as defined in Read Card (06 C0)", TryParse = null },
-                new BmpInfo { Id = 0x22, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "PAN / EF_ID, 'E' used to indicate a masked numeric digit1. If the card-number contains an odd number of digits, it is padded with an ‘F’.", TryParse = null },
+                new BmpInfo { Id = 0x22, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "PAN / EF_ID, 'E' used to indicate a masked numeric digit1. If the card-number contains an odd number of digits, it is padded with an ‘F’.", TryParse = ParsePanData },
                 new BmpInfo { Id = 0x23, DataLength = 2, CalculateDataLength = this.GetDataLengthLL, Description = "Track 2 data, without start and end markers; 'E' used to indicate a masked numeric digit", TryParse = null },
                 new BmpInfo { Id = 0x24, DataLength = 3, CalculateDataLength = this.GetDataLengthLLL, Description = "Track 3 data, without start and end markers; 'E' used to indicate a masked numeric digit", TryParse = null },
                 new BmpInfo { Id = 0x27, DataLength = 1, Description = "Result-Code as defined in chapter Error-Messages", TryParse = this.ParseErrorCode },
@@ -506,14 +506,21 @@ namespace Portalum.Zvt.Parsers
         private bool ParseErrorCode(byte[] data, IResponse response)
         {
             var errorMessage = this._errorMessageRepository.GetMessage(data[0]);
-
-            if (response is IResponseErrorMessage typedResponse)
+            bool parsed = false;
+            
+            if (response is IResponseErrorMessage typedErrorMessageResponse)
             {
-                typedResponse.ErrorMessage = errorMessage;
-                return true;
+                typedErrorMessageResponse.ErrorMessage = errorMessage;
+                parsed = true;
+            }
+            
+            if (response is IResponseErrorCode typedErrorCodeResponse)
+            {
+                typedErrorCodeResponse.ErrorCode = data[0];
+                parsed = true;
             }
 
-            return false;
+            return parsed;
         }
 
         private bool ParseTime(byte[] data, IResponse response)
@@ -729,6 +736,20 @@ namespace Portalum.Zvt.Parsers
             return false;
         }
 
+        private bool ParsePanData(byte[] data, IResponse response)
+        {
+            if (response is IResponseCardNumber typedResponse)
+            {
+                var cardNumber = BitConverter.ToString(data)
+                    .Replace("F", "")
+                    .Replace("-", "")
+                    .Replace("E", "*");
+                typedResponse.CardNumber = cardNumber;
+                return true;
+            }
+            return false;
+        }
+        
         private bool ParseCardName(byte[] data, IResponse response)
         {
             if (response is IResponseCardName typedResponse)

--- a/src/Portalum.Zvt/Parsers/BmpParser.cs
+++ b/src/Portalum.Zvt/Parsers/BmpParser.cs
@@ -286,7 +286,7 @@ namespace Portalum.Zvt.Parsers
                 new BmpInfo { Id = 0x06, DataLength = 0, Description = "TLV-container; length according to TLV-encoding (not LLL-Var !)", TryParse = tlvParser.Parse },
                 new BmpInfo { Id = 0x0B, DataLength = 3, Description = "Trace number", TryParse = this.ParseTraceNumber },
                 new BmpInfo { Id = 0x0C, DataLength = 3, Description = "Time, format HHMMSS", TryParse = this.ParseTime },
-                new BmpInfo { Id = 0x0D, DataLength = 2, Description = "Date, format MMDD (see also AA)", TryParse = null },
+                new BmpInfo { Id = 0x0D, DataLength = 2, Description = "Date, format MMDD (see also AA)", TryParse = this.ParseDate },
                 new BmpInfo { Id = 0x0E, DataLength = 2, Description = "Expiry-date, format YYMM", TryParse = this.ParseExpiryDate },
                 new BmpInfo { Id = 0x17, DataLength = 2, Description = "Card sequence-number", TryParse = this.ParseCardSequenceNumber },
                 new BmpInfo { Id = 0x19, DataLength = 1, Description = "Status-byte as defined in Registration (06 00) / Payment-type as defined in Authorization (06 01) / Card-type as defined in Read Card (06 C0)", TryParse = null },
@@ -506,7 +506,7 @@ namespace Portalum.Zvt.Parsers
         private bool ParseErrorCode(byte[] data, IResponse response)
         {
             var errorMessage = this._errorMessageRepository.GetMessage(data[0]);
-            bool parsed = false;
+            var parsed = false;
             
             if (response is IResponseErrorMessage typedErrorMessageResponse)
             {
@@ -568,6 +568,36 @@ namespace Portalum.Zvt.Parsers
 
                 typedResponse.ExpiryDateMonth = month;
                 typedResponse.ExpiryDateYear = year;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ParseDate(byte[] data, IResponse response)
+        {
+            if (response is IResponseDate typedResponse)
+            {
+                if (data.Length != 2)
+                {
+                    return false;
+                }
+
+                var dateString = ByteHelper.ByteArrayToHex(data);
+
+                if (!int.TryParse(dateString.Substring(0,2), out var month))
+                {
+                    return false;
+                }
+
+                if (!int.TryParse(dateString.Substring(2, 2), out var day))
+                {
+                    return false;
+                }
+
+                typedResponse.DateDay = day;
+                typedResponse.DateMonth = month;
 
                 return true;
             }

--- a/src/Portalum.Zvt/RegistrationConfig.cs
+++ b/src/Portalum.Zvt/RegistrationConfig.cs
@@ -35,6 +35,13 @@ namespace Portalum.Zvt
         /// Electronic Cash Register controls administration function
         /// </summary>
         public bool AllowAdministrationViaPaymentTerminal = false;
+        
+        /// <summary>
+        /// Payment terminal generates the receipt and sends it via print text line or print text block.
+        /// When disabled, the Electronic Cash Register only receives the status information and _no_ receipt.
+        /// It has to generate the receipt itself.
+        /// </summary>
+        public bool ReceiptPrintoutGeneratedViaPaymentTerminal = true;
 
         #endregion
 
@@ -84,8 +91,10 @@ namespace Portalum.Zvt
             {
                 configByte = BitHelper.SetBit(configByte, 5);
             }
-
-            configByte = BitHelper.SetBit(configByte, 7); //ECR print-type
+            if (this.ReceiptPrintoutGeneratedViaPaymentTerminal)
+            {
+                configByte = BitHelper.SetBit(configByte, 7);    
+            }
 
             return configByte;
         }

--- a/src/Portalum.Zvt/Responses/IResponseCardNumber.cs
+++ b/src/Portalum.Zvt/Responses/IResponseCardNumber.cs
@@ -1,0 +1,7 @@
+﻿namespace Portalum.Zvt.Responses
+{
+    public interface IResponseCardNumber
+    {
+        string CardNumber { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/Responses/IResponseDate.cs
+++ b/src/Portalum.Zvt/Responses/IResponseDate.cs
@@ -1,0 +1,15 @@
+﻿namespace Portalum.Zvt.Responses
+{
+    public interface IResponseDate
+    {
+        /// <summary>
+        /// The month of the date.
+        /// </summary>
+        public int DateMonth { get; set; }
+
+        /// <summary>
+        /// The day of the date.
+        /// </summary>
+        public int DateDay { get; set; }
+    }
+}

--- a/src/Portalum.Zvt/Responses/IResponseErrorCode.cs
+++ b/src/Portalum.Zvt/Responses/IResponseErrorCode.cs
@@ -1,0 +1,7 @@
+namespace Portalum.Zvt.Responses
+{
+    public interface IResponseErrorCode
+    {
+        byte ErrorCode { get; set; }
+    }
+}


### PR DESCRIPTION
# Summary

Generating receipts on the ECR has two main advantages:
* it eliminates all print receipt messages, which also reduces the potential window for connection issues and leaving the PT in an undesired state
* the ECR can generate the receipt in a format it desires

Currently generating receipts on the ECR is not possible because:
* the card number is not parsed in the status information
* the payment date is not parsed in the status information
* the registration config does not support turning off receipt printing

This PR extends the parsing capabilities of the status information parser to include the card number and payment date. It also extends the registration config with `ReceiptPrintoutGeneratedViaPaymentTerminal` which can then be used to disable receipt generation by the PT.

Additionally, while already messing with the parser, i have exposed the error code as a number. This allows developers to cleanly identify errors (e.g. a forced end-of-day). Until now you had to compare the error strings which IMO is not as clean, as error strings may change or be translated differently later down the line.

# Tests 

Real World tests: Tested with a Worldline VALINA Terminal from Card Complete.
Testcases: i have added / modified a couple of testcases to include the new fields.

# Backwards Compatibility

The newly introduced config flag's default value is chosen to be backwards compatible. 
