### PR TITLE
allow more options for injections / customizations

### DIFF
--- a/src/Portalum.Zvt/ReceiveHandler.cs
+++ b/src/Portalum.Zvt/ReceiveHandler.cs
@@ -16,25 +16,25 @@ namespace Portalum.Zvt
     /// </summary>
     public class ReceiveHandler : IReceiveHandler
     {
-        private readonly ILogger _logger;
-        private readonly IErrorMessageRepository _errorMessageRepository;
+        protected readonly ILogger _logger;
+        protected readonly IErrorMessageRepository _errorMessageRepository;
 
-        private readonly IPrintLineParser _printLineParser;
-        private readonly IPrintTextBlockParser _printTextBlockParser;
-        private readonly IStatusInformationParser _statusInformationParser;
-        private readonly IIntermediateStatusInformationParser _intermediateStatusInformationParser;
-        private readonly List<byte[]> _availableControlFields;
+        protected readonly IPrintLineParser _printLineParser;
+        protected readonly IPrintTextBlockParser _printTextBlockParser;
+        protected readonly IStatusInformationParser _statusInformationParser;
+        protected readonly IIntermediateStatusInformationParser _intermediateStatusInformationParser;
+        protected readonly List<byte[]> _availableControlFields;
 
-        private readonly byte[] _receiveBuffer = new byte[ushort.MaxValue];
-        private int _receiveBufferEndPosition = 0;
-        private int _missingDataOfExpectedPackage = 0;
+        protected readonly byte[] _receiveBuffer = new byte[ushort.MaxValue];
+        protected int _receiveBufferEndPosition = 0;
+        protected int _missingDataOfExpectedPackage = 0;
 
-        private readonly byte[] _statusInformationControlField = new byte[] { 0x04, 0x0F };
-        private readonly byte[] _intermediateStatusInformationControlField = new byte[] { 0x04, 0xFF };
-        private readonly byte[] _printLineControlField = new byte[] { 0x06, 0xD1 };
-        private readonly byte[] _printTextBlockControlField = new byte[] { 0x06, 0xD3 };
-        private readonly byte[] _completionCommandControlField = new byte[] { 0x06, 0x0F };
-        private readonly byte[] _abortCommandControlField = new byte[] { 0x06, 0x1E };
+        protected readonly byte[] _statusInformationControlField = new byte[] { 0x04, 0x0F };
+        protected readonly byte[] _intermediateStatusInformationControlField = new byte[] { 0x04, 0xFF };
+        protected readonly byte[] _printLineControlField = new byte[] { 0x06, 0xD1 };
+        protected readonly byte[] _printTextBlockControlField = new byte[] { 0x06, 0xD3 };
+        protected readonly byte[] _completionCommandControlField = new byte[] { 0x06, 0x0F };
+        protected readonly byte[] _abortCommandControlField = new byte[] { 0x06, 0x1E };
 
         /// <inheritdoc />
         public event Action<PrintLineInfo> LineReceived;
@@ -195,13 +195,13 @@ namespace Portalum.Zvt
             return this.ProcessApdu(apduInfo, apduData);
         }
 
-        private void ResetFragmentInfo()
+        protected virtual void ResetFragmentInfo()
         {
             this._receiveBufferEndPosition = 0;
             this._missingDataOfExpectedPackage = 0;
         }
 
-        private ProcessDataState ProcessApdu(
+        protected virtual ProcessDataState ProcessApdu(
             ApduResponseInfo apduInfo,
             Span<byte> apduData)
         {

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -62,11 +62,13 @@ namespace Portalum.Zvt
         /// <param name="logger"></param>
         /// <param name="clientConfig">ZVT Configuration</param>
         /// <param name="receiveHandler">Inject own receive handler</param>
+        /// <param name="zvtCommunication">Inject own ZVT Communication</param>
         public ZvtClient(
             IDeviceCommunication deviceCommunication,
             ILogger<ZvtClient> logger = default,
             ZvtClientConfig clientConfig = default,
-            IReceiveHandler receiveHandler = default)
+            IReceiveHandler receiveHandler = default,
+            ZvtCommunication zvtCommunication = default)
         {
             if (logger == null)
             {
@@ -99,8 +101,19 @@ namespace Portalum.Zvt
 
             #endregion
 
-            this._zvtCommunication = new ZvtCommunication(logger, deviceCommunication);
-            this._zvtCommunication.DataReceived += this.DataReceived;
+            # region ZvtCommunication
+            
+            if (zvtCommunication == default)
+            {
+                this._zvtCommunication = new ZvtCommunication(logger, deviceCommunication);
+            }
+            else
+            {
+                this._zvtCommunication = zvtCommunication;
+            }
+            this.RegisterZvtCommunicationHandlerEvents();
+
+            #endregion
         }
 
         /// <inheritdoc />
@@ -118,9 +131,9 @@ namespace Portalum.Zvt
         {
             if (disposing)
             {
-                this._zvtCommunication.DataReceived -= this.DataReceived;
+                this.UnregisterZvtCommunicationHandlerEvents();
                 this._zvtCommunication.Dispose();
-
+                
                 this.UnregisterReceiveHandlerEvents();
             }
         }
@@ -152,6 +165,16 @@ namespace Portalum.Zvt
 
             this._receiveHandler = new ReceiveHandler(this._logger, encoding, errorMessageRepository, intermediateStatusRepository);
             this.RegisterReceiveHandlerEvents();
+        }
+
+        private void RegisterZvtCommunicationHandlerEvents()
+        {
+            this._zvtCommunication.DataReceived += this.DataReceived;
+        }
+        
+        private void UnregisterZvtCommunicationHandlerEvents()
+        {
+            this._zvtCommunication.DataReceived -= this.DataReceived;
         }
 
         private void RegisterReceiveHandlerEvents()

--- a/src/Portalum.Zvt/ZvtCommunication.cs
+++ b/src/Portalum.Zvt/ZvtCommunication.cs
@@ -13,23 +13,23 @@ namespace Portalum.Zvt
     /// </summary>
     public class ZvtCommunication : IDisposable
     {
-        private readonly ILogger _logger;
-        private readonly IDeviceCommunication _deviceCommunication;
+        protected readonly ILogger _logger;
+        protected readonly IDeviceCommunication _deviceCommunication;
 
-        private CancellationTokenSource _acknowledgeReceivedCancellationTokenSource;
-        private byte[] _dataBuffer;
-        private bool _waitForAcknowledge = false;
+        protected CancellationTokenSource _acknowledgeReceivedCancellationTokenSource;
+        protected byte[] _dataBuffer;
+        protected bool _waitForAcknowledge = false;
 
         /// <summary>
         /// New data received from the pt device
         /// </summary>
         public event Func<byte[], bool> DataReceived;
 
-        private readonly byte[] _positiveCompletionData1 = new byte[] { 0x80, 0x00, 0x00 }; //Default
-        private readonly byte[] _positiveCompletionData2 = new byte[] { 0x84, 0x00, 0x00 }; //Alternative
-        private readonly byte[] _positiveCompletionData3 = new byte[] { 0x84, 0x9C, 0x00 }; //Special case for request more time
-        private readonly byte[] _otherCommandData = new byte[] { 0x84, 0x83, 0x00 };
-        private readonly byte _negativeCompletionPrefix = 0x84;
+        protected readonly byte[] _positiveCompletionData1 = new byte[] { 0x80, 0x00, 0x00 }; //Default
+        protected readonly byte[] _positiveCompletionData2 = new byte[] { 0x84, 0x00, 0x00 }; //Alternative
+        protected readonly byte[] _positiveCompletionData3 = new byte[] { 0x84, 0x9C, 0x00 }; //Special case for request more time
+        protected readonly byte[] _otherCommandData = new byte[] { 0x84, 0x83, 0x00 };
+        protected readonly byte _negativeCompletionPrefix = 0x84;
 
         /// <summary>
         /// ZvtCommunication
@@ -46,7 +46,7 @@ namespace Portalum.Zvt
         }
 
         /// <inheritdoc />
-        public void Dispose()
+        public virtual void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
@@ -68,7 +68,7 @@ namespace Portalum.Zvt
         /// Switch for incoming data
         /// </summary>
         /// <param name="data"></param>
-        private void DataReceiveSwitch(byte[] data)
+        protected virtual void DataReceiveSwitch(byte[] data)
         {
             if (this._waitForAcknowledge)
             {
@@ -79,13 +79,13 @@ namespace Portalum.Zvt
             this.ProcessData(data);
         }
 
-        private void AddDataToBuffer(byte[] data)
+        protected virtual void AddDataToBuffer(byte[] data)
         {
             this._dataBuffer = data;
             this._acknowledgeReceivedCancellationTokenSource?.Cancel();
         }
 
-        private void ProcessData(byte[] data)
+        protected virtual void ProcessData(byte[] data)
         {
             var dataProcessed = this.DataReceived?.Invoke(data);
             if (dataProcessed.HasValue && dataProcessed.Value)
@@ -102,7 +102,7 @@ namespace Portalum.Zvt
         /// <param name="acknowledgeReceiveTimeoutMilliseconds">Maximum waiting time for the acknowledge package, default is 5 seconds, T3 Timeout</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<SendCommandResult> SendCommandAsync(
+        public async virtual Task<SendCommandResult> SendCommandAsync(
             byte[] commandData,
             int acknowledgeReceiveTimeoutMilliseconds = 5000,
             CancellationToken cancellationToken = default)
@@ -164,7 +164,7 @@ namespace Portalum.Zvt
             return SendCommandResult.UnknownFailure;
         }
 
-        private bool CheckIsPositiveCompletion()
+        protected virtual bool CheckIsPositiveCompletion()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -191,7 +191,7 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private bool CheckIsNegativeCompletion()
+        protected virtual bool CheckIsNegativeCompletion()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -209,7 +209,7 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private bool CheckIsNotSupported()
+        protected virtual bool CheckIsNotSupported()
         {
             if (this._dataBuffer.Length < 3)
             {
@@ -226,12 +226,12 @@ namespace Portalum.Zvt
             return false;
         }
 
-        private void ResetDataBuffer()
+        protected virtual void ResetDataBuffer()
         {
             this._dataBuffer = null;
         }
 
-        private void ForwardUnusedBufferData()
+        protected virtual void ForwardUnusedBufferData()
         {
             if (this._dataBuffer.Length == 3)
             {


### PR DESCRIPTION
## Summary

This PR enables you to pass a custom `ZvtCommunication` class to the Zvt client. A custom `ReceiveHandler` can already be injected but this is sometimes not enough to cover a specific case. It also changes most members of those classes to `protected` / `virtual` to allow for simple subclassing.

I do understand if you dislike these changes from a code-style point of view and reject this proposal.

## Backwards Compatibility

From the protocol side no changes are introduced, there should not be any issues.

