### PR TITLE
Manufacturer specific IntermediateStates

### DIFF
--- a/src/Portalum.Zvt/Repositories/IngenicoEnglishIntermediateStatusRepository.cs
+++ b/src/Portalum.Zvt/Repositories/IngenicoEnglishIntermediateStatusRepository.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+
+namespace Portalum.Zvt.Repositories
+{
+    public class IngenicoEnglishIntermediateStatusRepository : IIntermediateStatusRepository
+    {
+        private readonly Dictionary<byte, string> _statusCodes;
+
+        /// <summary>
+        /// Ingenico English IntermediateStatusRepository
+        /// </summary>
+        public IngenicoEnglishIntermediateStatusRepository()
+        {
+            this._statusCodes = new Dictionary<byte, string>
+            {
+                { 0x00, "PT is waiting for amount-confirmation" },
+                { 0x01, "Please watch PIN-Pad" },
+                { 0x02, "Please watch PIN-Pad" },
+                { 0x03, "Not accepted" },
+                { 0x04, "PT is waiting for response from FEP" },
+                { 0x05, "PT is sending auto-reversal" },
+                { 0x06, "PT is sending post-bookings" },
+                { 0x07, "Card not admitted" },
+                { 0x08, "Card unknown / undefined" },
+                { 0x09, "Expired card" },
+                { 0x0A, "Insert card" },
+                { 0x0B, "Please remove card!" },
+                { 0x0C, "Card not readable" },
+                { 0x0D, "Processing error" },
+                { 0x0E, "Please wait..." },
+                { 0x0F, "PT is commencing an automatic end-ofday batch" },
+                { 0x10, "Invalid card" },
+                { 0x11, "Balance display" },
+                { 0x12, "System malfunction" },
+                { 0x13, "Payment not possible" },
+                { 0x14, "Credit not sufficient" },
+                { 0x15, "Incorrect PIN" },
+                { 0x16, "Limit not sufficient" },
+                { 0x17, "Please wait..." },
+                { 0x18, "PIN try limit exceeded" },
+                { 0x19, "Card-data incorrect" },
+                { 0x1A, "Service-mode" },
+                { 0x1B, "Approved. Please fill-up" },
+                { 0x1C, "Approved. Please take goods" },
+                { 0x1D, "Declined" },
+                { 0x26, "PT is waiting for input of the mobilenumber" },
+                { 0x27, "PT is waiting for repeat of mobile number" },
+                { 0x28, "Currency selection, please wait..." },
+                { 0x29, "Language selection, please wait..." },
+                { 0x2A, "For loading please insert card" },
+                { 0x2B, "Emergency transaction, please wait" },
+                { 0x2C, "Application selection, please wait" },
+                { 0x41, "Please watch PIN-Pad\nPlease remove card!" },
+                { 0x42, "Please watch PIN-Pad\nPlease remove card!" },
+                { 0x43, "Not accepted\nPlease remove card!" },
+                { 0x44, "PT is waiting for response from FEP\nPlease remove card!" },
+                { 0x45, "PT is sending auto-reversal\nPlease remove card!" },
+                { 0x46, "PT is sending post-booking\nPlease remove card!" },
+                { 0x47, "Card not admitted\nPlease remove card!" },
+                { 0x48, "Card unknown / undefined\nPlease remove card!" },
+                { 0x49, "Expired card\nPlease remove card!" },
+                { 0x4A, "" }, //No text in the documentation
+                { 0x4B, "Please remove card!" },
+                { 0x4C, "Card not readable\nPlease remove card!" },
+                { 0x4D, "Processing error\nPlease remove card!" },
+                { 0x4E, "Please wait\nPlease remove card!" },
+                { 0x4F, "PT is commencing an automatic end-ofday batch\nPlease remove card!" },
+                { 0x50, "Invalid card\nPlease remove card!" },
+                { 0x51, "Balance display\nPlease remove card!" },
+                { 0x52, "System malfunction\nPlease remove card!" },
+                { 0x53, "Payment not possible\nPlease remove card!" },
+                { 0x54, "Credit not sufficient\nPlease remove card!" },
+                { 0x55, "Incorrect PIN\nPlease remove card!" },
+                { 0x56, "Limit not sufficient\nPlease remove card!" },
+                { 0x57, "Please wait...\nPlease remove card!" },
+                { 0x58, "PIN try limit exceeded\nPlease remove card!" },
+                { 0x59, "Card-data incorrect\nPlease remove card!" },
+                { 0x5A, "Service-mode\nPlease remove card!" },
+                { 0x5B, "Approved. Please fill-up\nPlease remove card!" },
+                { 0x5C, "Approved. Please take goods\nPlease remove card!" },
+                { 0x5D, "Declined\nPlease remove card!" },
+                { 0x66, "PT is waiting for input of the mobil-number\nPlease remove card!" },
+                { 0x67, "PT is waiting for repeat of the mobilnumber\nPlease remove card!" },
+                { 0x68, "PT has detected customer card insertion" },
+                { 0x69, "Please select DCC" },
+                { 0xA0, "Payment processed" },
+                { 0xA1, "Payment processed\nPlease remove card!" },
+                { 0xA2, "Cancellation successful" },
+                { 0xA3, "Cancellation successful\nPlease remove card!" },
+                { 0xA4, "Cancellation not possible" },
+                { 0xA5, "Cancellation not possible\nPlease remove card!" },
+                { 0xC7, "PT is waiting for input of the mileage" },
+                { 0xC8, "PT is waiting for cashier" },
+                { 0xC9, "PT is commencing an automatic diagnosis" },
+                { 0xCA, "PT is commencing an automatic initialisation" },
+                { 0xCB, "Merchant-journal full" },
+                { 0xCC, "Debit advice not possible, PIN required" },
+                { 0xD2, "Connecting dial-up" },
+                { 0xD3, "Dial-up connection made" },
+                { 0xE0, "PT is waiting for application-selection" },
+                { 0xE1, "PT is waiting for language-selection" },
+                { 0xE2, "PT requests to use the cleaning card" },
+                { 0xF1, "Offline" },
+                { 0xF2, "Online" },
+                { 0xF3, "Offline transaction" },
+                { 0xFF, "no appropriate ZVT status code matches the status. See TLV tags 24 and 07" }
+            };
+        }
+
+        /// <inheritdoc />
+        public string GetMessage(byte errorCode)
+        {
+            if (this._statusCodes.TryGetValue(errorCode, out var errorMessage))
+            {
+                return errorMessage;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Portalum.Zvt/Repositories/IngenicoGermanIntermediateStatusRepository.cs
+++ b/src/Portalum.Zvt/Repositories/IngenicoGermanIntermediateStatusRepository.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Generic;
+
+namespace Portalum.Zvt.Repositories
+{  
+
+    /// <summary>
+    /// Ingenico German IntermediateStatusRepository
+    /// </summary>
+    public class IngenicoGermanIntermediateStatusRepository : IIntermediateStatusRepository
+    {
+        private readonly Dictionary<byte, string> _statusCodes;
+
+        /// <summary>
+        /// Ingenico German IntermediateStatusRepository
+        /// </summary>
+        public IngenicoGermanIntermediateStatusRepository()
+        {
+            this._statusCodes = new Dictionary<byte, string>
+            {
+                { 0x00, "BZT wartet auf Betragbestätigung" },
+                { 0x01, "Bitte Anzeigen auf dem PIN-Pad beachten" },
+                { 0x02, "Bitte Anzeigen auf dem PIN-Pad beachten" },
+                { 0x03, "Vorgang nicht möglich" },
+                { 0x04, "BZT wartet auf Antwort vom FEP" },
+                { 0x05, "BZT sendet Autostorno" },
+                { 0x06, "BZT sendet Nachbuchungen" },
+                { 0x07, "Karte nicht zugelassen" },
+                { 0x08, "Karte unbekannt / undefiniert" },
+                { 0x09, "Karte verfallen " },
+                { 0x0A, "Karte einstecken" },
+                { 0x0B, "Bitte Karte entnehmen!" },
+                { 0x0C, "Karte nicht lesbar" },
+                { 0x0D, "Vorgang abgebrochen" },
+                { 0x0E, "Vorgang wird bearbeitet bitte warten..." },
+                { 0x0F, "BZT leitet einen automatischen Kassenabschluss ein" },
+                { 0x10, "Karte ungültig" },
+                { 0x11, "Guthabenanzeige" },
+                { 0x12, "Systemfehler" },
+                { 0x13, "Zahlung nicht möglich" },
+                { 0x14, "Guthaben nicht ausreichend" },
+                { 0x15, "Geheimzahl falsch" },
+                { 0x16, "Limit nicht ausreichend" },
+                { 0x17, "Bitte warten..." },
+                { 0x18, "Geheimzahl zu oft falsch" },
+                { 0x19, "Kartendaten falsch" },
+                { 0x1A, "Servicemodus" },
+                { 0x1B, "Autorisierung erfolgt. Bitte tanken" },
+                { 0x1C, "Zahlung erfolgt. Bitte Ware entnehmen" },
+                { 0x1D, "Autorisierung nicht möglich" },
+                { 0x26, "BZT wartet auf Eingabe der Mobilfunknummer" },
+                { 0x27, "BZT wartet auf Wiederholung der Mobilfunknummer" },
+                { 0x28, "Währungsauswahl, bitte warten..." },
+                { 0x29, "Sprachauswahl, bitte warten..." },
+                { 0x2A, "Zum Laden Karte einstecken" },
+                { 0x2B, "Offline-Notbetrieb, bitte warten" },
+                { 0x2C, "Auswahl Debit/Kredit, bitte warten " },
+                { 0x41, "Bitte Anzeigen auf dem PIN-Pad beachten\nBitte Karte entnehmen!" },
+                { 0x42, "Bitte Anzeigen auf dem PIN-Pad beachten\nBitte Karte entnehmen!" },
+                { 0x43, "Vorgang nicht möglich\nBitte Karte entnehmen!" },
+                { 0x44, "BZT wartet auf Antwort vom FEP\nBitte Karte entnehmen!" },
+                { 0x45, "BZT sendet Autostorno\nBitte Karte entnehmen!" },
+                { 0x46, "BZT sendet Nachbuchungen\nBitte Karte entnehmen!" },
+                { 0x47, "Karte nicht zugelassen\nBitte Karte entnehmen!" },
+                { 0x48, "Karte unbekannt / undefiniert\nBitte Karte entnehmen!" },
+                { 0x49, "Karte verfallen\nBitte Karte entnehmen!" },
+                { 0x4A, "" }, //Textfeld in der Dokumentation leer
+                { 0x4B, "Bitte Karte entnehmen!" },
+                { 0x4C, "Karte nicht lesbar\nBitte Karte entnehmen!" },
+                { 0x4D, "Vorgang abgebrochen\nBitte Karte entnehmen!" },
+                { 0x4E, "Vorgang wird bearbeitet bitte warten...\nBitte Karte entnehmen!" },
+                { 0x4F, "BZT leitet einen automatischen Kassenabschluss ein\nBitte Karte entnehmen!" },
+                { 0x50, "Karte ungültig\nBitte Karte entnehmen!" },
+                { 0x51, "Guthabenanzeige\nBitte Karte entnehmen!" },
+                { 0x52, "Systemfehler\nBitte Karte entnehmen!" },
+                { 0x53, "Zahlung nicht möglich\nBitte Karte entnehmen!" },
+                { 0x54, "Guthaben nicht ausreichend\nBitte Karte entnehmen!" },
+                { 0x55, "Geheimzahl falsch\nBitte Karte entnehmen!" },
+                { 0x56, "Limit nicht ausreichend\nBitte Karte entnehmen!" },
+                { 0x57, "Bitte warten...\nBitte Karte entnehmen!" },
+                { 0x58, "Geheimzahl zu oft falsch\nBitte Karte entnehmen!" },
+                { 0x59, "Kartendaten falsch\nBitte Karte entnehmen!" },
+                { 0x5A, "Servicemodus\nBitte Karte entnehmen!" },
+                { 0x5B, "Autorisierung erfolgt. Bitte tanken\nBitte Karte entnehmen!" },
+                { 0x5C, "Zahlung erfolgt. Bitte Ware entnehmen\nBitte Karte entnehmen!" },
+                { 0x5D, "Autorisierung nicht möglich\nBitte Karte entnehmen!" },
+                { 0x66, "BZT wartet auf Eingabe der Mobilfunknummer\nBitte Karte entnehmen!" },
+                { 0x67, "BZT wartet auf Wiederholung der Mobilfunknummer\nBitte Karte entnehmen!" },
+                { 0x68, "BZT hat Einstecken der Kundenkarte erkannt" },
+                { 0x69, "Bitte DCC auswählen" },
+                { 0xA0, "Zahlung erfolgt" },
+                { 0xA1, "Zahlung erfolgt\nBitte Karte entnehmen!" },
+                { 0xA2, "Storno erfolgt" },
+                { 0xA3, "Storno erfolgt\nBitte Karte entnehmen!" },
+                { 0xA4, "Storno nicht möglich" },
+                { 0xA5, "Storno nicht möglich\nBitte Karte entnehmen!" },
+                { 0xC7, "BZT wartet auf Eingabe des Kilometerstands" },
+                { 0xC8, "BZT wartet auf Kassierer" },
+                { 0xC9, "BZT leitet eine automatische Diagnose ein" },
+                { 0xCA, "BZT leitet eine automatische Initialisierung ein" },
+                { 0xCB, "Händlerjournal voll" },
+                { 0xCC, "Lastschrift nicht möglich, PIN notwendig" },
+                { 0xD2, "DFÜ-Verbindung wird hergestellt" },
+                { 0xD3, "DFÜ-Verbindung besteht" },
+                { 0xE0, "BZT wartet auf Anwendungsauswahl" },
+                { 0xE1, "BZT wartet auf Sprachauswahl" },
+                { 0xE2, "BZT fordert auf, die Reinungskarte zu benutzen" },
+                { 0xF1, "Offline" },
+                { 0xF2, "Online" },
+                { 0xF3, "Offline-Transaktion" },
+                { 0xFF, "kein geeigneter ZVT-Statuscode zu demdem Status. Siehe TLV-Tags 24 und 07" }
+            };
+        }
+
+        /// <inheritdoc />
+        public string GetMessage(byte errorCode)
+        {
+            if (this._statusCodes.TryGetValue(errorCode, out var errorMessage))
+            {
+                return errorMessage;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -107,7 +107,7 @@ namespace Portalum.Zvt
 
             if (receiveHandler == default)
             {
-                this.InitializeReceiveHandler(clientConfig.Language, this.GetEncoding(clientConfig.Encoding));
+                this.InitializeReceiveHandler(clientConfig.Language, this.GetEncoding(clientConfig.Encoding),clientConfig.IntermediateSateExtension);
             }
             else
             {
@@ -179,10 +179,11 @@ namespace Portalum.Zvt
 
         private void InitializeReceiveHandler(
             Language language,
-            Encoding encoding)
+            Encoding encoding,
+            ZvtIntermediateSateExtension intermediateSateExtension)
         {
             IErrorMessageRepository errorMessageRepository = this.GetErrorMessageRepository(language);
-            IIntermediateStatusRepository intermediateStatusRepository = this.GetIntermediateStatusRepository(language);
+            IIntermediateStatusRepository intermediateStatusRepository = this.GetIntermediateStatusRepository(language,intermediateSateExtension);
 
             this._receiveHandler = new ReceiveHandler(this._logger, encoding, errorMessageRepository, intermediateStatusRepository);
             this.RegisterReceiveHandlerEvents();
@@ -220,14 +221,28 @@ namespace Portalum.Zvt
             return new EnglishErrorMessageRepository();
         }
 
-        private IIntermediateStatusRepository GetIntermediateStatusRepository(Language language)
+        private IIntermediateStatusRepository GetIntermediateStatusRepository(Language language, ZvtIntermediateSateExtension intermediateSateExtension)
         {
             if (language == Language.German)
             {
-                return new GermanIntermediateStatusRepository();
+                if (intermediateSateExtension == ZvtIntermediateSateExtension.Ingenico)
+                {
+                    return new IngenicoGermanIntermediateStatusRepository();
+                }
+                else
+                {
+                    return new GermanIntermediateStatusRepository();
+                }
             }
 
-            return new EnglishIntermediateStatusRepository();
+            if (intermediateSateExtension == ZvtIntermediateSateExtension.Ingenico)
+            {
+                return new IngenicoEnglishIntermediateStatusRepository();
+            }
+            else
+            {
+                return new EnglishIntermediateStatusRepository();
+            }
         }
 
         private void ProcessIntermediateStatusInformationReceived(string message)

--- a/src/Portalum.Zvt/ZvtClientConfig.cs
+++ b/src/Portalum.Zvt/ZvtClientConfig.cs
@@ -34,5 +34,10 @@ namespace Portalum.Zvt
         /// every 2 (ZVT standard) to 4 (observed in practice) seconds for the completion status.
         /// </summary>
         public byte GetAsyncCompletionInfoLimit = 10;
+
+        /// <summary>
+        /// Manufacturer specific IntermediateState statustext repositories.
+        /// </summary>
+        public ZvtIntermediateSateExtension IntermediateSateExtension = ZvtIntermediateSateExtension.generic;
     }
 }

--- a/src/Portalum.Zvt/ZvtIntermediateStateExtension.cs
+++ b/src/Portalum.Zvt/ZvtIntermediateStateExtension.cs
@@ -1,0 +1,17 @@
+﻿namespace Portalum.Zvt
+{
+    /// <summary>
+    /// Manufacturer specific extensions
+    /// </summary>
+    public enum ZvtIntermediateSateExtension
+    {
+        /// <summary>
+        /// official ZVT (Rev. 13.09)
+        /// </summary>
+        generic,
+        /// <summary>
+        /// Ingenico A32.de ECR Interface Version 1.3.41
+        /// </summary>
+        Ingenico
+    }
+}


### PR DESCRIPTION
Implementation of extensions Ingenico did to the IntermediateStates.

Added new Classes, with the additional Codes, for the Ingenico ZVT extensions.
The configuratiuon ist is part of the ZvtClientConfig and is set at instantiation.

This implementation was necessary, because at the end of the payment process, the intermediate states came without texts. On our devices, when using an ingenico terminal, it looked like the process ot stuck for a while. 
With this implementation we get seamless status information again.