### PR TITLE
Typo in StatusInformationParser.cs SetCardTechnology

### DIFF
--- a/src/Portalum.Zvt/Parsers/StatusInformationParser.cs
+++ b/src/Portalum.Zvt/Parsers/StatusInformationParser.cs
@@ -133,7 +133,7 @@ namespace Portalum.Zvt.Parsers
                 switch (cardTechnology)
                 {
                     case 0x00:
-                        typedResponse.CardTechnology = "Magentic stripe";
+                        typedResponse.CardTechnology = "Magnetic stripe";
                         break;
                     case 0x01:
                         typedResponse.CardTechnology = "Chip";


### PR DESCRIPTION
Currently for 0x00 the CardTechnology is parsed to "Magentic" stripe instead of  "Magnetic" stripe. This fixes the typo.